### PR TITLE
ci: add explorer-api image build to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,20 +7,24 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
-    name: Build (${{ matrix.platform }})
+    name: Build ${{ matrix.image }} (${{ matrix.platform }})
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: linux/amd64
+        image:
+          - name: qfc-explorer
+            dockerfile: Dockerfile
+          - name: qfc-explorer-api
+            dockerfile: Dockerfile.indexer
+        platform:
+          - arch: linux/amd64
             runner: ubuntu-latest
-          - platform: linux/arm64
+          - arch: linux/arm64
             runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
       packages: write
@@ -37,24 +41,25 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - id: platform
-        run: echo "pair=${platform//\//-}" >> $GITHUB_OUTPUT
+        run: echo "pair=${arch//\//-}" >> $GITHUB_OUTPUT
         env:
-          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.platform.arch }}
 
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/qfc-network/${{ matrix.image.name }}
 
       - uses: docker/build-push-action@v5
         id: build
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          file: ${{ matrix.image.dockerfile }}
+          platforms: ${{ matrix.platform.arch }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
-          cache-to: type=gha,scope=${{ steps.platform.outputs.pair }},mode=max
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.image.name }}-${{ steps.platform.outputs.pair }}
+          cache-to: type=gha,scope=${{ matrix.image.name }}-${{ steps.platform.outputs.pair }},mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/qfc-network/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - run: |
           mkdir -p /tmp/digests
@@ -63,15 +68,18 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ steps.platform.outputs.pair }}
+          name: digests-${{ matrix.image.name }}-${{ steps.platform.outputs.pair }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
   merge:
-    name: Merge Manifest
+    name: Merge Manifest (${{ matrix.image }})
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      matrix:
+        image: [qfc-explorer, qfc-explorer-api]
     permissions:
       contents: read
       packages: write
@@ -80,7 +88,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ matrix.image }}-*
           merge-multiple: true
 
       - uses: docker/login-action@v3
@@ -92,7 +100,7 @@ jobs:
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/qfc-network/${{ matrix.image }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -104,7 +112,7 @@ jobs:
       - run: |
           cd /tmp/digests
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/qfc-network/${{ matrix.image }}@sha256:%s ' *)
 
       - name: Update qfc-testnet image tag
         if: github.ref_type == 'branch'
@@ -112,11 +120,12 @@ jobs:
         env:
           SHORT_SHA: ${{ github.sha }}
           BRANCH: ${{ github.ref_name }}
+          SERVICE: ${{ matrix.image == 'qfc-explorer' && 'explorer' || 'explorer-api' }}
         run: |
           TAG="${BRANCH}-sha-${SHORT_SHA:0:7}"
           curl -sf -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.TESTNET_DISPATCH_TOKEN }}" \
             https://api.github.com/repos/qfc-network/qfc-testnet/dispatches \
-            -d "{\"event_type\":\"image-published\",\"client_payload\":{\"service\":\"explorer\",\"tag\":\"${TAG}\",\"branch\":\"${BRANCH}\",\"sha\":\"${{ github.sha }}\"}}"
-          echo "Dispatched qfc-testnet update: ${TAG}"
+            -d "{\"event_type\":\"image-published\",\"client_payload\":{\"service\":\"${SERVICE}\",\"tag\":\"${TAG}\",\"branch\":\"${BRANCH}\",\"sha\":\"${{ github.sha }}\"}}"
+          echo "Dispatched qfc-testnet update: ${SERVICE} → ${TAG}"


### PR DESCRIPTION
## Summary
- `qfc-explorer-api` image (`Dockerfile.indexer`) was never built by CI — only `qfc-explorer` (frontend) was built
- This caused `staging-sha-xxx` tags to not exist in GHCR for explorer-api, breaking immutable tag deployments
- Added explorer-api as a parallel matrix build with separate manifest merge and testnet dispatch

## Changes
- Expanded build matrix to include both `qfc-explorer` (Dockerfile) and `qfc-explorer-api` (Dockerfile.indexer)
- Each image gets its own merge manifest job and testnet dispatch
- Cache scopes are per-image to avoid conflicts

## Test plan
- [ ] Merge to staging and verify both images are pushed to GHCR with `staging-sha-<commit>` tags
- [ ] Verify testnet dispatch fires for both `explorer` and `explorer-api` services
- [ ] Remove `.env` overrides on VPS-A and confirm compose defaults work

🤖 Generated with [Claude Code](https://claude.com/claude-code)