### PR TITLE
revert: remove explorer-api build from explorer CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,24 +7,20 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
-    name: Build ${{ matrix.image }} (${{ matrix.platform }})
+    name: Build (${{ matrix.platform }})
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - name: qfc-explorer
-            dockerfile: Dockerfile
-          - name: qfc-explorer-api
-            dockerfile: Dockerfile.indexer
-        platform:
-          - arch: linux/amd64
+        include:
+          - platform: linux/amd64
             runner: ubuntu-latest
-          - arch: linux/arm64
+          - platform: linux/arm64
             runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.platform.runner }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -41,25 +37,24 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - id: platform
-        run: echo "pair=${arch//\//-}" >> $GITHUB_OUTPUT
+        run: echo "pair=${platform//\//-}" >> $GITHUB_OUTPUT
         env:
-          arch: ${{ matrix.platform.arch }}
+          platform: ${{ matrix.platform }}
 
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ${{ env.REGISTRY }}/qfc-network/${{ matrix.image.name }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - uses: docker/build-push-action@v5
         id: build
         with:
           context: .
-          file: ${{ matrix.image.dockerfile }}
-          platforms: ${{ matrix.platform.arch }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.image.name }}-${{ steps.platform.outputs.pair }}
-          cache-to: type=gha,scope=${{ matrix.image.name }}-${{ steps.platform.outputs.pair }},mode=max
-          outputs: type=image,name=${{ env.REGISTRY }}/qfc-network/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
+          cache-to: type=gha,scope=${{ steps.platform.outputs.pair }},mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - run: |
           mkdir -p /tmp/digests
@@ -68,18 +63,15 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.image.name }}-${{ steps.platform.outputs.pair }}
+          name: digests-${{ steps.platform.outputs.pair }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
   merge:
-    name: Merge Manifest (${{ matrix.image }})
+    name: Merge Manifest
     runs-on: ubuntu-latest
     needs: build
-    strategy:
-      matrix:
-        image: [qfc-explorer, qfc-explorer-api]
     permissions:
       contents: read
       packages: write
@@ -88,7 +80,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-${{ matrix.image }}-*
+          pattern: digests-*
           merge-multiple: true
 
       - uses: docker/login-action@v3
@@ -100,7 +92,7 @@ jobs:
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ${{ env.REGISTRY }}/qfc-network/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -112,7 +104,7 @@ jobs:
       - run: |
           cd /tmp/digests
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/qfc-network/${{ matrix.image }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Update qfc-testnet image tag
         if: github.ref_type == 'branch'
@@ -120,12 +112,11 @@ jobs:
         env:
           SHORT_SHA: ${{ github.sha }}
           BRANCH: ${{ github.ref_name }}
-          SERVICE: ${{ matrix.image == 'qfc-explorer' && 'explorer' || 'explorer-api' }}
         run: |
           TAG="${BRANCH}-sha-${SHORT_SHA:0:7}"
           curl -sf -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.TESTNET_DISPATCH_TOKEN }}" \
             https://api.github.com/repos/qfc-network/qfc-testnet/dispatches \
-            -d "{\"event_type\":\"image-published\",\"client_payload\":{\"service\":\"${SERVICE}\",\"tag\":\"${TAG}\",\"branch\":\"${BRANCH}\",\"sha\":\"${{ github.sha }}\"}}"
-          echo "Dispatched qfc-testnet update: ${SERVICE} → ${TAG}"
+            -d "{\"event_type\":\"image-published\",\"client_payload\":{\"service\":\"explorer\",\"tag\":\"${TAG}\",\"branch\":\"${BRANCH}\",\"sha\":\"${{ github.sha }}\"}}"
+          echo "Dispatched qfc-testnet update: ${TAG}"


### PR DESCRIPTION
explorer-api has its own repo (qfc-network/qfc-explorer-api), should not be built here.