### PR TITLE
feat: miner dashboard — earnings chart, score gauge, vesting timeline, ROI calculator

### DIFF
--- a/src/app/miner/[address]/page.tsx
+++ b/src/app/miner/[address]/page.tsx
@@ -9,6 +9,10 @@ import SectionHeader from '@/components/SectionHeader';
 import Table from '@/components/Table';
 import CopyButton from '@/components/CopyButton';
 import TranslatedText from '@/components/TranslatedText';
+import MinerScoreGauge from '@/components/MinerScoreGauge';
+import MinerEarningsChart from '@/components/MinerEarningsChart';
+import VestingTimeline from '@/components/VestingTimeline';
+import MinerRoiCalculator from '@/components/MinerRoiCalculator';
 
 export default async function MinerDetailPage({
   params,
@@ -84,7 +88,24 @@ export default async function MinerDetailPage({
         </div>
       </div>
 
-      {/* Vesting schedule */}
+      {/* Score gauge + Earnings chart (side by side on desktop) */}
+      <div className="mt-6 grid gap-4 lg:grid-cols-[280px_1fr]">
+        {Number(miner.contributionScore) > 0 && (
+          <MinerScoreGauge score={miner.contributionScore} />
+        )}
+        <div className={Number(miner.contributionScore) > 0 ? '' : 'lg:col-span-2'}>
+          <MinerEarningsChart earnings={miner.earnings} />
+        </div>
+      </div>
+
+      {/* Vesting timeline */}
+      {miner.tranches.length > 0 && (
+        <section className="mt-6">
+          <VestingTimeline tranches={miner.tranches} />
+        </section>
+      )}
+
+      {/* Vesting schedule table */}
       <section className="mt-8 space-y-4">
         <SectionHeader
           title="Vesting Schedule"
@@ -184,6 +205,11 @@ export default async function MinerDetailPage({
             },
           ]}
         />
+      </section>
+
+      {/* ROI Calculator */}
+      <section className="mt-8">
+        <MinerRoiCalculator totalEarned={miner.totalEarned} earnings={miner.earnings} />
       </section>
     </main>
   );

--- a/src/components/MinerEarningsChart.tsx
+++ b/src/components/MinerEarningsChart.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { formatHexWeiToQfc } from '@/lib/qfc-format';
+
+type Earning = {
+  blockHeight: string;
+  reward: string;
+  timestamp: string;
+};
+
+type Props = {
+  earnings: Earning[];
+};
+
+type Period = '24h' | '7d' | '30d' | 'all';
+
+function hexWeiToNumber(hexWei: string): number {
+  try {
+    const wei = BigInt(hexWei.startsWith('0x') ? hexWei : `0x${hexWei}`);
+    // Convert to QFC (18 decimals) as a float
+    const whole = Number(wei / 10n ** 18n);
+    const frac = Number(wei % 10n ** 18n) / 1e18;
+    return whole + frac;
+  } catch {
+    return 0;
+  }
+}
+
+function formatAxisValue(value: number): string {
+  if (value >= 1e6) return `${(value / 1e6).toFixed(1)}M`;
+  if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K`;
+  if (value < 1 && value > 0) return value.toFixed(4);
+  return value.toFixed(2);
+}
+
+export default function MinerEarningsChart({ earnings }: Props) {
+  const [period, setPeriod] = useState<Period>('7d');
+
+  const aggregated = useMemo(() => {
+    if (!earnings || earnings.length === 0) return [];
+
+    const now = Date.now();
+    const cutoffs: Record<Period, number> = {
+      '24h': now - 24 * 60 * 60 * 1000,
+      '7d': now - 7 * 24 * 60 * 60 * 1000,
+      '30d': now - 30 * 24 * 60 * 60 * 1000,
+      all: 0,
+    };
+
+    const cutoff = cutoffs[period];
+    const filtered = earnings.filter((e) => Number(e.timestamp) >= cutoff);
+
+    if (filtered.length === 0) return [];
+
+    // Aggregate by bucket
+    const buckets = new Map<string, number>();
+
+    for (const e of filtered) {
+      const ts = Number(e.timestamp);
+      const date = new Date(ts);
+      let key: string;
+
+      if (period === '24h') {
+        // Aggregate hourly
+        key = `${date.getMonth() + 1}/${date.getDate()} ${date.getHours()}:00`;
+      } else {
+        // Aggregate daily
+        key = `${date.getMonth() + 1}/${date.getDate()}`;
+      }
+
+      const current = buckets.get(key) ?? 0;
+      buckets.set(key, current + hexWeiToNumber(e.reward));
+    }
+
+    return Array.from(buckets.entries()).map(([label, value]) => ({ label, value }));
+  }, [earnings, period]);
+
+  const chartData = useMemo(() => {
+    if (aggregated.length === 0) {
+      return { points: [], maxValue: 0, minValue: 0 };
+    }
+
+    const values = aggregated.map((d) => d.value);
+    const maxValue = Math.max(...values, 0.0001);
+    const minValue = 0;
+    const range = maxValue - minValue || 1;
+
+    const points = aggregated.map((d, i) => ({
+      x: (i / (aggregated.length - 1 || 1)) * 100,
+      y: ((d.value - minValue) / range) * 100,
+      label: d.label,
+      value: d.value,
+    }));
+
+    return { points, maxValue, minValue };
+  }, [aggregated]);
+
+  const periods: { key: Period; label: string }[] = [
+    { key: '24h', label: '24h' },
+    { key: '7d', label: '7d' },
+    { key: '30d', label: '30d' },
+    { key: 'all', label: 'All' },
+  ];
+
+  const { points, maxValue, minValue } = chartData;
+
+  // Total for the period
+  const periodTotal = aggregated.reduce((sum, d) => sum + d.value, 0);
+
+  return (
+    <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 p-5">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-white">Earnings Over Time</h3>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Total: {periodTotal.toFixed(4)} QFC
+          </p>
+        </div>
+        <div className="flex gap-1 rounded-lg bg-slate-100 dark:bg-slate-800 p-0.5">
+          {periods.map((p) => (
+            <button
+              key={p.key}
+              onClick={() => setPeriod(p.key)}
+              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                period === p.key
+                  ? 'bg-emerald-500 text-white shadow-sm'
+                  : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white'
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {aggregated.length === 0 ? (
+        <div className="flex items-center justify-center h-[200px] text-sm text-slate-500 dark:text-slate-400">
+          No earnings data for this period
+        </div>
+      ) : (
+        <div className="relative" style={{ height: 220 }}>
+          {/* Y-axis labels */}
+          <div className="absolute left-0 top-0 bottom-8 flex w-16 flex-col justify-between text-right text-xs text-slate-500 pr-2">
+            <span>{formatAxisValue(maxValue)} QFC</span>
+            <span>{formatAxisValue((maxValue + minValue) / 2)} QFC</span>
+            <span>{formatAxisValue(minValue)}</span>
+          </div>
+
+          {/* Chart area */}
+          <div className="absolute left-16 right-0 top-0 bottom-8">
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 100 100"
+              preserveAspectRatio="none"
+              className="h-full w-full"
+            >
+              {/* Grid lines */}
+              <line x1="0" y1="0" x2="100" y2="0" stroke="#334155" strokeWidth="0.5" />
+              <line x1="0" y1="50" x2="100" y2="50" stroke="#334155" strokeWidth="0.5" strokeDasharray="2,2" />
+              <line x1="0" y1="100" x2="100" y2="100" stroke="#334155" strokeWidth="0.5" />
+
+              {/* Area fill */}
+              {points.length > 1 && (
+                <path
+                  d={`${points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${100 - p.y}`).join(' ')} L ${points[points.length - 1].x} 100 L 0 100 Z`}
+                  fill="#10b98120"
+                />
+              )}
+
+              {/* Line */}
+              {points.length > 1 && (
+                <path
+                  d={points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${100 - p.y}`).join(' ')}
+                  fill="none"
+                  stroke="#10b981"
+                  strokeWidth="2"
+                  vectorEffect="non-scaling-stroke"
+                />
+              )}
+
+              {/* Data points */}
+              {points.map((p, i) => (
+                <g key={i}>
+                  <circle
+                    cx={p.x}
+                    cy={100 - p.y}
+                    r="3"
+                    fill="#10b981"
+                    className="opacity-0 hover:opacity-100 transition-opacity cursor-pointer"
+                  />
+                  <title>{`${p.label}: ${p.value.toFixed(4)} QFC`}</title>
+                </g>
+              ))}
+            </svg>
+          </div>
+
+          {/* X-axis labels */}
+          <div className="absolute left-16 right-0 bottom-0 h-8 flex justify-between text-xs text-slate-500">
+            {points
+              .filter((_, i) => i % Math.ceil(points.length / 6) === 0 || i === points.length - 1)
+              .map((p, i) => (
+                <span key={i} className="text-center truncate" style={{ maxWidth: '60px' }}>
+                  {p.label}
+                </span>
+              ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MinerRoiCalculator.tsx
+++ b/src/components/MinerRoiCalculator.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+
+type Props = {
+  totalEarned: string;
+  earnings: Array<{ reward: string; timestamp: string }>;
+};
+
+function hexWeiToNumber(hexWei: string): number {
+  try {
+    const wei = BigInt(hexWei.startsWith('0x') ? hexWei : `0x${hexWei}`);
+    const whole = Number(wei / 10n ** 18n);
+    const frac = Number(wei % 10n ** 18n) / 1e18;
+    return whole + frac;
+  } catch {
+    return 0;
+  }
+}
+
+export default function MinerRoiCalculator({ totalEarned, earnings }: Props) {
+  const [collapsed, setCollapsed] = useState(true);
+  const [electricityCost, setElectricityCost] = useState(0.12);
+  const [gpuPower, setGpuPower] = useState(250);
+  const [hardwareCost, setHardwareCost] = useState(1000);
+  const [qfcPrice, setQfcPrice] = useState(0.01);
+
+  const calculations = useMemo(() => {
+    // Calculate average daily revenue from earnings data
+    if (!earnings || earnings.length < 2) {
+      return null;
+    }
+
+    const timestamps = earnings.map((e) => Number(e.timestamp)).sort((a, b) => a - b);
+    const totalQfc = earnings.reduce((sum, e) => sum + hexWeiToNumber(e.reward), 0);
+    const timeSpanMs = timestamps[timestamps.length - 1] - timestamps[0];
+    const timeSpanDays = timeSpanMs / (1000 * 60 * 60 * 24);
+
+    if (timeSpanDays <= 0) return null;
+
+    const dailyRevenueQfc = totalQfc / timeSpanDays;
+    const dailyRevenueUsd = dailyRevenueQfc * qfcPrice;
+
+    // Electricity cost: watts / 1000 * 24h * $/kWh
+    const dailyElectricityCost = (gpuPower / 1000) * 24 * electricityCost;
+    const dailyNetProfit = dailyRevenueUsd - dailyElectricityCost;
+    const monthlyProjection = dailyNetProfit * 30;
+
+    // Payback period
+    const paybackDays = dailyNetProfit > 0 ? hardwareCost / dailyNetProfit : Infinity;
+
+    return {
+      dailyRevenueQfc,
+      dailyRevenueUsd,
+      dailyElectricityCost,
+      dailyNetProfit,
+      monthlyProjection,
+      paybackDays,
+      timeSpanDays,
+    };
+  }, [earnings, electricityCost, gpuPower, hardwareCost, qfcPrice]);
+
+  return (
+    <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60">
+      {/* Collapsible header */}
+      <button
+        onClick={() => setCollapsed(!collapsed)}
+        className="w-full flex items-center justify-between p-5 text-left hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors rounded-2xl"
+      >
+        <div>
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-white">ROI Calculator</h3>
+          <p className="text-xs text-slate-500 dark:text-slate-400">Estimate your mining profitability</p>
+        </div>
+        <svg
+          className={`w-5 h-5 text-slate-400 transition-transform ${collapsed ? '' : 'rotate-180'}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {!collapsed && (
+        <div className="px-5 pb-5 border-t border-slate-200 dark:border-slate-800 pt-4">
+          {/* Input fields */}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-6">
+            <div>
+              <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
+                Electricity Cost ($/kWh)
+              </label>
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                value={electricityCost}
+                onChange={(e) => setElectricityCost(Number(e.target.value))}
+                className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
+                GPU Power Draw (W)
+              </label>
+              <input
+                type="number"
+                step="10"
+                min="0"
+                value={gpuPower}
+                onChange={(e) => setGpuPower(Number(e.target.value))}
+                className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
+                Hardware Cost ($)
+              </label>
+              <input
+                type="number"
+                step="100"
+                min="0"
+                value={hardwareCost}
+                onChange={(e) => setHardwareCost(Number(e.target.value))}
+                className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
+                QFC Price ($)
+              </label>
+              <input
+                type="number"
+                step="0.001"
+                min="0"
+                value={qfcPrice}
+                onChange={(e) => setQfcPrice(Number(e.target.value))}
+                className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+          </div>
+
+          {/* Results */}
+          {calculations ? (
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              <ResultCard
+                label="Daily Revenue"
+                primary={`${calculations.dailyRevenueQfc.toFixed(4)} QFC`}
+                secondary={`$${calculations.dailyRevenueUsd.toFixed(4)}`}
+              />
+              <ResultCard
+                label="Daily Electricity"
+                primary={`-$${calculations.dailyElectricityCost.toFixed(4)}`}
+                negative
+              />
+              <ResultCard
+                label="Daily Net Profit"
+                primary={`$${calculations.dailyNetProfit.toFixed(4)}`}
+                positive={calculations.dailyNetProfit > 0}
+                negative={calculations.dailyNetProfit <= 0}
+              />
+              <ResultCard
+                label="Monthly Projection"
+                primary={`$${calculations.monthlyProjection.toFixed(2)}`}
+                positive={calculations.monthlyProjection > 0}
+                negative={calculations.monthlyProjection <= 0}
+              />
+              <ResultCard
+                label="Payback Period"
+                primary={
+                  calculations.paybackDays === Infinity
+                    ? 'Never (negative ROI)'
+                    : `${Math.ceil(calculations.paybackDays)} days`
+                }
+                secondary={
+                  calculations.paybackDays !== Infinity
+                    ? `~${(calculations.paybackDays / 30).toFixed(1)} months`
+                    : undefined
+                }
+                negative={calculations.paybackDays === Infinity}
+              />
+              <ResultCard
+                label="Based On"
+                primary={`${calculations.timeSpanDays.toFixed(1)} days`}
+                secondary={`${earnings.length} earnings recorded`}
+              />
+            </div>
+          ) : (
+            <div className="text-center py-6 text-sm text-slate-500 dark:text-slate-400">
+              Not enough earnings data to calculate ROI. At least 2 earnings entries with different timestamps are required.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ResultCard({
+  label,
+  primary,
+  secondary,
+  positive,
+  negative,
+}: {
+  label: string;
+  primary: string;
+  secondary?: string;
+  positive?: boolean;
+  negative?: boolean;
+}) {
+  return (
+    <div className="rounded-xl bg-slate-50 dark:bg-slate-800/60 p-4">
+      <p className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">{label}</p>
+      <p
+        className={`mt-1 text-lg font-bold ${
+          positive
+            ? 'text-emerald-600 dark:text-emerald-400'
+            : negative
+              ? 'text-red-500 dark:text-red-400'
+              : 'text-slate-900 dark:text-white'
+        }`}
+      >
+        {primary}
+      </p>
+      {secondary && (
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">{secondary}</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/MinerScoreGauge.tsx
+++ b/src/components/MinerScoreGauge.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useMemo } from 'react';
+
+type Props = {
+  score: string;
+  maxScore?: number;
+};
+
+export default function MinerScoreGauge({ score, maxScore = 1000 }: Props) {
+  const numericScore = Number(score) || 0;
+
+  const { color, label, strokeDasharray, strokeDashoffset } = useMemo(() => {
+    const pct = Math.min(numericScore / maxScore, 1);
+
+    // Color zones: red (0-33%) -> yellow (33-66%) -> green (66-100%)
+    let color: string;
+    let label: string;
+    if (pct < 0.33) {
+      color = '#ef4444'; // red-500
+      label = 'Low';
+    } else if (pct < 0.66) {
+      color = '#eab308'; // yellow-500
+      label = 'Medium';
+    } else {
+      color = '#22c55e'; // green-500
+      label = 'High';
+    }
+
+    // SVG circle math: radius=45, circumference = 2*pi*45 = ~282.74
+    // We draw a 270-degree arc (3/4 of circle)
+    const circumference = 2 * Math.PI * 45;
+    const arcLength = circumference * 0.75; // 270 degrees
+    const filledLength = arcLength * pct;
+
+    return {
+      color,
+      label,
+      strokeDasharray: `${arcLength} ${circumference}`,
+      strokeDashoffset: -(arcLength - filledLength),
+    };
+  }, [numericScore, maxScore]);
+
+  const circumference = 2 * Math.PI * 45;
+  const arcLength = circumference * 0.75;
+
+  return (
+    <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 p-5">
+      <h3 className="text-sm font-semibold text-slate-900 dark:text-white mb-3">Contribution Score</h3>
+
+      <div className="flex flex-col items-center">
+        <svg width="160" height="140" viewBox="0 0 120 110" className="overflow-visible">
+          {/* Background arc */}
+          <circle
+            cx="60"
+            cy="60"
+            r="45"
+            fill="none"
+            stroke="currentColor"
+            className="text-slate-200 dark:text-slate-700"
+            strokeWidth="10"
+            strokeLinecap="round"
+            strokeDasharray={`${arcLength} ${circumference}`}
+            transform="rotate(135 60 60)"
+          />
+
+          {/* Filled arc */}
+          <circle
+            cx="60"
+            cy="60"
+            r="45"
+            fill="none"
+            stroke={color}
+            strokeWidth="10"
+            strokeLinecap="round"
+            strokeDasharray={`${arcLength * Math.min(numericScore / maxScore, 1)} ${circumference}`}
+            transform="rotate(135 60 60)"
+            className="transition-all duration-700"
+          />
+
+          {/* Score text */}
+          <text
+            x="60"
+            y="55"
+            textAnchor="middle"
+            className="fill-slate-900 dark:fill-white text-2xl font-bold"
+            style={{ fontSize: '24px', fontWeight: 700 }}
+          >
+            {numericScore}
+          </text>
+
+          {/* Label */}
+          <text
+            x="60"
+            y="75"
+            textAnchor="middle"
+            fill={color}
+            style={{ fontSize: '11px', fontWeight: 600 }}
+          >
+            {label}
+          </text>
+
+          {/* Min/Max labels */}
+          <text
+            x="12"
+            y="100"
+            textAnchor="middle"
+            className="fill-slate-400 dark:fill-slate-500"
+            style={{ fontSize: '9px' }}
+          >
+            0
+          </text>
+          <text
+            x="108"
+            y="100"
+            textAnchor="middle"
+            className="fill-slate-400 dark:fill-slate-500"
+            style={{ fontSize: '9px' }}
+          >
+            {maxScore}
+          </text>
+        </svg>
+
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+          out of {maxScore} max
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/VestingTimeline.tsx
+++ b/src/components/VestingTimeline.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useMemo } from 'react';
+import { formatHexWeiToQfc } from '@/lib/qfc-format';
+
+type Tranche = {
+  blockHeight: string;
+  amount: string;
+  vested: string;
+  startTime: string;
+  cliffEnd: string;
+  endTime: string;
+  percentVested: number;
+};
+
+type Props = {
+  tranches: Tranche[];
+};
+
+function formatCountdown(targetMs: number): string {
+  const now = Date.now();
+  const diff = targetMs - now;
+  if (diff <= 0) return 'Unlocked';
+
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+
+  if (days > 0) return `${days}d ${hours}h remaining`;
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+  return `${hours}h ${minutes}m remaining`;
+}
+
+function formatDate(ms: string | number): string {
+  const d = new Date(Number(ms));
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export default function VestingTimeline({ tranches }: Props) {
+  if (!tranches || tranches.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 p-5">
+      <h3 className="text-sm font-semibold text-slate-900 dark:text-white mb-4">Vesting Timeline</h3>
+
+      <div className="space-y-5">
+        {tranches.map((tranche, idx) => {
+          const startMs = Number(tranche.startTime);
+          const cliffMs = Number(tranche.cliffEnd);
+          const endMs = Number(tranche.endTime);
+          const now = Date.now();
+          const totalDuration = endMs - startMs || 1;
+          const cliffPct = Math.min(100, ((cliffMs - startMs) / totalDuration) * 100);
+          const currentPct = Math.min(100, Math.max(0, ((now - startMs) / totalDuration) * 100));
+          const isCliffActive = now < cliffMs;
+
+          // Determine next unlock event
+          let nextEvent: string;
+          if (now < cliffMs) {
+            nextEvent = `Cliff ends: ${formatCountdown(cliffMs)}`;
+          } else if (now < endMs) {
+            nextEvent = `Fully vests: ${formatCountdown(endMs)}`;
+          } else {
+            nextEvent = 'Fully vested';
+          }
+
+          return (
+            <div key={idx} className="space-y-2">
+              {/* Header row */}
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-medium text-slate-700 dark:text-slate-300">
+                    Block #{tranche.blockHeight}
+                  </span>
+                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                    {formatHexWeiToQfc(tranche.amount)} QFC
+                  </span>
+                </div>
+                <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                  {tranche.percentVested}% vested
+                </span>
+              </div>
+
+              {/* Timeline bar */}
+              <div className="relative h-6 w-full rounded-full bg-slate-100 dark:bg-slate-800 overflow-hidden">
+                {/* Cliff zone */}
+                <div
+                  className="absolute inset-y-0 left-0 bg-amber-500/30 dark:bg-amber-500/20"
+                  style={{ width: `${cliffPct}%` }}
+                  title={`Cliff period: ${formatDate(tranche.startTime)} - ${formatDate(tranche.cliffEnd)}`}
+                />
+
+                {/* Vested progress */}
+                <div
+                  className="absolute inset-y-0 left-0 bg-emerald-500/60 dark:bg-emerald-500/40 transition-all duration-500"
+                  style={{ width: `${Math.min(100, tranche.percentVested)}%` }}
+                />
+
+                {/* Current position indicator */}
+                {currentPct > 0 && currentPct < 100 && (
+                  <div
+                    className="absolute inset-y-0 w-0.5 bg-white dark:bg-slate-200 shadow-sm"
+                    style={{ left: `${currentPct}%` }}
+                    title="Current position"
+                  />
+                )}
+
+                {/* Labels within bar */}
+                <div className="absolute inset-0 flex items-center px-2">
+                  {cliffPct > 15 && (
+                    <span
+                      className="text-[9px] font-medium text-amber-800 dark:text-amber-300 truncate"
+                      style={{ width: `${cliffPct}%` }}
+                    >
+                      Cliff
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {/* Date labels */}
+              <div className="flex items-center justify-between text-[10px] text-slate-400 dark:text-slate-500">
+                <span>{formatDate(tranche.startTime)}</span>
+                <span className="text-emerald-600 dark:text-emerald-400 font-medium text-xs">
+                  {nextEvent}
+                </span>
+                <span>{formatDate(tranche.endTime)}</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **MinerEarningsChart**: Custom SVG line chart with period tabs (24h/7d/30d/All), area fill, earnings aggregation
- **MinerScoreGauge**: Circular SVG gauge showing contribution score (0-1000) with color zones
- **VestingTimeline**: Horizontal timeline bars per tranche with cliff/unlock indicators and countdown
- **MinerRoiCalculator**: Collapsible calculator with electricity cost, GPU power, hardware cost inputs
- Updated `/miner/[address]` page layout to integrate all components

Closes qfc-network/qfc-design#30, qfc-network/qfc-design#31, qfc-network/qfc-design#32

## Test plan
- [ ] Visit `/miner/<address>` — verify earnings chart renders with period switching
- [ ] Verify score gauge shows contribution score with correct color zone
- [ ] Verify vesting timeline shows cliff → unlock progression
- [ ] Verify ROI calculator expands/collapses and computes correct values
- [ ] Test on mobile viewport — responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)