### PR TITLE
feat: add /miners list page with navigation

### DIFF
--- a/src/app/miners/page.tsx
+++ b/src/app/miners/page.tsx
@@ -1,0 +1,225 @@
+export const dynamic = "force-dynamic";
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { fetchJsonSafe } from '@/lib/api-client';
+import type { ApiMinersList, ApiRegisteredMiner } from '@/lib/api-types';
+import { formatNumber, shortenHash } from '@/lib/format';
+import SectionHeader from '@/components/SectionHeader';
+import StatsCard from '@/components/StatsCard';
+import Table from '@/components/Table';
+import TranslatedText from '@/components/TranslatedText';
+
+export const metadata: Metadata = {
+  title: 'Inference Miners',
+  description: 'Registered inference miners on the QFC network.',
+  openGraph: {
+    title: 'Inference Miners | QFC Explorer',
+    description: 'Registered inference miners on the QFC network.',
+    type: 'website',
+  },
+};
+
+const PAGE_SIZE = 25;
+
+/** Tier display label */
+function tierLabel(tier: number): string {
+  switch (tier) {
+    case 3: return 'T3';
+    case 2: return 'T2';
+    case 1: return 'T1';
+    default: return `T${tier}`;
+  }
+}
+
+/** Tier badge CSS classes */
+function tierClasses(tier: number): string {
+  switch (tier) {
+    case 3: return 'bg-emerald-500/20 text-emerald-400';
+    case 2: return 'bg-amber-500/20 text-amber-400';
+    case 1: return 'bg-slate-500/20 text-slate-400';
+    default: return 'bg-slate-500/20 text-slate-400';
+  }
+}
+
+/** Backend badge CSS classes */
+function backendClasses(backend: string): string {
+  const b = backend.toUpperCase();
+  if (b.includes('CUDA')) return 'bg-green-500/20 text-green-400';
+  if (b.includes('METAL')) return 'bg-blue-500/20 text-blue-400';
+  if (b.includes('ROCM')) return 'bg-red-500/20 text-red-400';
+  return 'bg-slate-500/20 text-slate-400'; // CPU or unknown
+}
+
+/** Format VRAM in GB */
+function formatVram(mb: number): string {
+  if (mb >= 1024) {
+    const gb = mb / 1024;
+    return `${gb % 1 === 0 ? gb.toFixed(0) : gb.toFixed(1)} GB`;
+  }
+  return `${mb} MB`;
+}
+
+export default async function MinersPage({
+  searchParams,
+}: {
+  searchParams: { page?: string };
+}) {
+  const page = Math.max(1, Number(searchParams.page ?? '1'));
+
+  const response = await fetchJsonSafe<ApiMinersList>(
+    `/api/miners?page=${page}&limit=${PAGE_SIZE}`,
+    { next: { revalidate: 30 } }
+  );
+
+  const miners = response?.data.items ?? [];
+  const totalMiners = response?.data.total ?? 0;
+
+  // Compute tier breakdown
+  const tierCounts: Record<number, number> = {};
+  const backendCounts: Record<string, number> = {};
+  for (const m of miners) {
+    tierCounts[m.tier] = (tierCounts[m.tier] ?? 0) + 1;
+    backendCounts[m.backend] = (backendCounts[m.backend] ?? 0) + 1;
+  }
+  const tierBreakdown = [3, 2, 1]
+    .filter((t) => tierCounts[t])
+    .map((t) => `T${t}: ${tierCounts[t]}`)
+    .join(' / ') || '--';
+
+  // Top backend
+  let topBackend = '--';
+  let topBackendCount = 0;
+  for (const [backend, count] of Object.entries(backendCounts)) {
+    if (count > topBackendCount) {
+      topBackend = backend;
+      topBackendCount = count;
+    }
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6">
+      <SectionHeader
+        title={<TranslatedText tKey="miners.title" />}
+        description={<TranslatedText tKey="miners.description" />}
+      />
+
+      {/* Summary cards */}
+      <section className="grid gap-4 sm:grid-cols-3">
+        <StatsCard
+          label={<TranslatedText tKey="miners.totalMiners" />}
+          value={formatNumber(totalMiners)}
+        />
+        <StatsCard
+          label={<TranslatedText tKey="miners.byTier" />}
+          value={tierBreakdown}
+        />
+        <StatsCard
+          label={<TranslatedText tKey="miners.topBackend" />}
+          value={topBackend}
+          sub={topBackendCount > 0 ? `${topBackendCount} miners` : undefined}
+        />
+      </section>
+
+      {/* Miners table */}
+      <Table<ApiRegisteredMiner>
+        rows={miners}
+        keyField="address"
+        emptyMessage="No miners registered yet."
+        columns={[
+          {
+            key: 'rank',
+            header: '#',
+            render: (_row, index) => (
+              <span className="text-slate-500">{(page - 1) * PAGE_SIZE + (index ?? 0) + 1}</span>
+            ),
+          },
+          {
+            key: 'address',
+            header: 'Address',
+            render: (row) => (
+              <Link
+                href={`/miner/${row.address}`}
+                className="font-mono text-sm text-slate-800 dark:text-slate-200 hover:text-cyan-400 transition-colors"
+              >
+                {shortenHash(row.address)}
+              </Link>
+            ),
+          },
+          {
+            key: 'gpuModel',
+            header: 'GPU Model',
+            render: (row) => (
+              <span className="text-slate-600 dark:text-slate-300 text-sm">
+                {row.gpuModel || '--'}
+              </span>
+            ),
+          },
+          {
+            key: 'tier',
+            header: 'Tier',
+            render: (row) => (
+              <span
+                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${tierClasses(row.tier)}`}
+              >
+                {tierLabel(row.tier)}
+              </span>
+            ),
+          },
+          {
+            key: 'vramMb',
+            header: 'VRAM',
+            render: (row) => (
+              <span className="font-mono text-slate-600 dark:text-slate-300 text-sm">
+                {formatVram(row.vramMb)}
+              </span>
+            ),
+          },
+          {
+            key: 'backend',
+            header: 'Backend',
+            render: (row) => (
+              <span
+                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${backendClasses(row.backend)}`}
+              >
+                {row.backend}
+              </span>
+            ),
+          },
+          {
+            key: 'contributionScore',
+            header: 'Score',
+            render: (row) => (
+              <span className="font-mono text-slate-600 dark:text-slate-300 text-sm">
+                {row.contributionScore}
+              </span>
+            ),
+          },
+        ]}
+      />
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between text-sm text-slate-400">
+        <Link
+          href={`/miners?page=${Math.max(1, page - 1)}`}
+          className={`rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 transition-colors hover:text-slate-900 dark:hover:text-white ${
+            page <= 1 ? 'pointer-events-none opacity-40' : ''
+          }`}
+        >
+          <TranslatedText tKey="common.previous" />
+        </Link>
+        <span>
+          <TranslatedText tKey="common.page" /> {page}
+        </span>
+        <Link
+          href={`/miners?page=${page + 1}`}
+          className={`rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 transition-colors hover:text-slate-900 dark:hover:text-white ${
+            miners.length < PAGE_SIZE ? 'pointer-events-none opacity-40' : ''
+          }`}
+        >
+          <TranslatedText tKey="common.next" />
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -45,6 +45,7 @@ const NAV_ITEMS: NavItem[] = [
     labelKey: 'nav.network',
     children: [
       { labelKey: 'nav.validators', href: '/validators' },
+      { labelKey: 'nav.miners', href: '/miners' },
       { labelKey: 'nav.networkStatus', href: '/network' },
       { labelKey: 'nav.analytics', href: '/analytics' },
       { labelKey: 'nav.leaderboard', href: '/leaderboard' },

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -753,6 +753,26 @@ export type ApiTokenTransfersList = ApiOk<{
   }>;
 }>;
 
+// --- Registered Miners List ---
+
+export type ApiRegisteredMiner = {
+  address: string;
+  gpuModel: string;
+  benchmarkScore: number;
+  tier: number;
+  vramMb: number;
+  backend: string;
+  registeredAt: string;
+  contributionScore: string;
+};
+
+export type ApiMinersList = ApiOk<{
+  page: number;
+  limit: number;
+  total: number;
+  items: ApiRegisteredMiner[];
+}>;
+
 // --- Miner Revenue ---
 
 export type ApiMinerDetail = ApiOk<{

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -757,6 +757,20 @@ const en = {
   'activity.wed': 'Wed',
   'activity.fri': 'Fri',
 
+  // Miners list page
+  'nav.miners': 'Miners',
+  'miners.title': 'Inference Miners',
+  'miners.description': 'Registered inference miners on the QFC network.',
+  'miners.totalMiners': 'Total Miners',
+  'miners.byTier': 'By Tier',
+  'miners.topBackend': 'Top Backend',
+  'miners.gpuModel': 'GPU Model',
+  'miners.tier': 'Tier',
+  'miners.vram': 'VRAM',
+  'miners.backend': 'Backend',
+  'miners.score': 'Score',
+  'miners.noMiners': 'No miners registered yet.',
+
   // Miner Revenue Dashboard
   'miner.title': 'Miner',
   'miner.notFound': 'Miner not found',

--- a/src/lib/translations/ja.ts
+++ b/src/lib/translations/ja.ts
@@ -751,6 +751,20 @@ const ja: Record<string, string> = {
   'activity.wed': '水',
   'activity.fri': '金',
 
+  // Miners list page
+  'nav.miners': 'マイナー',
+  'miners.title': '推論マイナー',
+  'miners.description': 'QFCネットワークに登録された推論マイナー。',
+  'miners.totalMiners': 'マイナー総数',
+  'miners.byTier': 'ティア別',
+  'miners.topBackend': 'トップバックエンド',
+  'miners.gpuModel': 'GPUモデル',
+  'miners.tier': 'ティア',
+  'miners.vram': 'VRAM',
+  'miners.backend': 'バックエンド',
+  'miners.score': 'スコア',
+  'miners.noMiners': '登録済みマイナーはありません。',
+
   // Miner Revenue Dashboard
   'miner.title': 'マイナー',
   'miner.notFound': 'マイナーが見つかりません',

--- a/src/lib/translations/ko.ts
+++ b/src/lib/translations/ko.ts
@@ -751,6 +751,20 @@ const ko: Record<string, string> = {
   'activity.wed': '수',
   'activity.fri': '금',
 
+  // Miners list page
+  'nav.miners': '마이너',
+  'miners.title': '추론 마이너',
+  'miners.description': 'QFC 네트워크에 등록된 추론 마이너.',
+  'miners.totalMiners': '총 마이너',
+  'miners.byTier': '티어별',
+  'miners.topBackend': '상위 백엔드',
+  'miners.gpuModel': 'GPU 모델',
+  'miners.tier': '티어',
+  'miners.vram': 'VRAM',
+  'miners.backend': '백엔드',
+  'miners.score': '점수',
+  'miners.noMiners': '등록된 마이너가 없습니다.',
+
   // Miner Revenue Dashboard
   'miner.title': '마이너',
   'miner.notFound': '마이너를 찾을 수 없습니다',

--- a/src/lib/translations/zh.ts
+++ b/src/lib/translations/zh.ts
@@ -751,6 +751,20 @@ const zh: Record<string, string> = {
   'activity.wed': '周三',
   'activity.fri': '周五',
 
+  // Miners list page
+  'nav.miners': '矿工',
+  'miners.title': '推理矿工',
+  'miners.description': 'QFC 网络上已注册的推理矿工。',
+  'miners.totalMiners': '矿工总数',
+  'miners.byTier': '按等级',
+  'miners.topBackend': '主要后端',
+  'miners.gpuModel': 'GPU 型号',
+  'miners.tier': '等级',
+  'miners.vram': '显存',
+  'miners.backend': '后端',
+  'miners.score': '分数',
+  'miners.noMiners': '暂无注册矿工。',
+
   // Miner Revenue Dashboard
   'miner.title': '矿工',
   'miner.notFound': '未找到矿工',


### PR DESCRIPTION
## Summary

- Add `/miners` page showing all registered inference miners in a table
- Summary cards: total miners, tier breakdown (T1/T2/T3), top backend
- Table columns: rank, address, GPU model, tier (color-coded), VRAM, backend, contribution score
- Pagination support
- Add "Miners" link to Network dropdown in navbar
- i18n: translation keys for en/zh/ja/ko

Part of the miners list page feature (cross-repo with qfc-core and qfc-explorer-api).

## Test plan
- [x] `npm run typecheck` passes
- [ ] Visual verification on testnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)