### PR TITLE
feat: display hardware profile on miner detail page

### DIFF
--- a/src/app/miner/[address]/page.tsx
+++ b/src/app/miner/[address]/page.tsx
@@ -88,6 +88,77 @@ export default async function MinerDetailPage({
         </div>
       </div>
 
+      {/* Hardware profile */}
+      {miner.gpuModel && (
+        <section className="mt-6 rounded-xl border border-slate-200 dark:border-slate-800 bg-white/60 dark:bg-slate-900/40 p-5">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-slate-500 mb-4">
+            <TranslatedText tKey="miner.hardwareProfile" />
+          </h2>
+          <div className="grid gap-x-8 gap-y-3 sm:grid-cols-2 lg:grid-cols-3 text-sm">
+            <div>
+              <span className="text-slate-500">GPU</span>
+              <p className="font-medium text-slate-900 dark:text-white">{miner.gpuModel}</p>
+            </div>
+            <div>
+              <span className="text-slate-500">VRAM</span>
+              <p className="font-medium text-slate-900 dark:text-white">
+                {miner.vramMb >= 1024 ? `${(miner.vramMb / 1024).toFixed(1)} GB` : `${miner.vramMb} MB`}
+              </p>
+            </div>
+            <div>
+              <span className="text-slate-500">Backend</span>
+              <p className="font-medium text-slate-900 dark:text-white">{miner.backend}</p>
+            </div>
+            {miner.cpuModel && (
+              <div>
+                <span className="text-slate-500">CPU</span>
+                <p className="font-medium text-slate-900 dark:text-white">{miner.cpuModel}</p>
+              </div>
+            )}
+            {miner.cpuCores > 0 && (
+              <div>
+                <span className="text-slate-500">CPU Cores</span>
+                <p className="font-medium text-slate-900 dark:text-white">{miner.cpuCores}</p>
+              </div>
+            )}
+            {miner.totalMemoryMb > 0 && (
+              <div>
+                <span className="text-slate-500">RAM</span>
+                <p className="font-medium text-slate-900 dark:text-white">
+                  {(miner.totalMemoryMb / 1024).toFixed(1)} GB
+                </p>
+              </div>
+            )}
+            {miner.os && (
+              <div>
+                <span className="text-slate-500">OS</span>
+                <p className="font-medium text-slate-900 dark:text-white">
+                  {miner.os}{miner.arch ? ` (${miner.arch})` : ''}
+                </p>
+              </div>
+            )}
+            {miner.tier > 0 && (
+              <div>
+                <span className="text-slate-500">Tier</span>
+                <p className="font-medium text-slate-900 dark:text-white">T{miner.tier}</p>
+              </div>
+            )}
+            {miner.benchmarkScore > 0 && (
+              <div>
+                <span className="text-slate-500">Benchmark</span>
+                <p className="font-medium text-slate-900 dark:text-white">{miner.benchmarkScore}</p>
+              </div>
+            )}
+            {miner.version && (
+              <div>
+                <span className="text-slate-500">Miner Version</span>
+                <p className="font-medium text-slate-900 dark:text-white">v{miner.version}</p>
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+
       {/* Score gauge + Earnings chart (side by side on desktop) */}
       <div className="mt-6 grid gap-4 lg:grid-cols-[280px_1fr]">
         {Number(miner.contributionScore) > 0 && (

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -764,6 +764,10 @@ export type ApiRegisteredMiner = {
   backend: string;
   os: string;
   arch: string;
+  cpuModel: string;
+  cpuCores: number;
+  totalMemoryMb: number;
+  version: string;
   registeredAt: string;
   contributionScore: string;
 };
@@ -784,6 +788,19 @@ export type ApiMinerDetail = ApiOk<{
   available: string;
   activeTranches: number;
   contributionScore: string;
+  // Hardware profile
+  gpuModel: string;
+  benchmarkScore: number;
+  tier: number;
+  vramMb: number;
+  backend: string;
+  os: string;
+  arch: string;
+  cpuModel: string;
+  cpuCores: number;
+  totalMemoryMb: number;
+  version: string;
+  registeredAt: string;
   earnings: Array<{
     blockHeight: string;
     reward: string;

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -791,6 +791,7 @@ const en = {
   'miner.progress': 'Progress',
   'miner.cliffEnd': 'Cliff End',
   'miner.endTime': 'End Time',
+  'miner.hardwareProfile': 'Hardware Profile',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/lib/translations/ja.ts
+++ b/src/lib/translations/ja.ts
@@ -785,6 +785,7 @@ const ja: Record<string, string> = {
   'miner.progress': '進捗',
   'miner.cliffEnd': 'クリフ終了',
   'miner.endTime': '終了時間',
+  'miner.hardwareProfile': 'ハードウェアプロファイル',
 };
 
 export default ja;

--- a/src/lib/translations/ko.ts
+++ b/src/lib/translations/ko.ts
@@ -785,6 +785,7 @@ const ko: Record<string, string> = {
   'miner.progress': '진행률',
   'miner.cliffEnd': '클리프 종료',
   'miner.endTime': '종료 시간',
+  'miner.hardwareProfile': '하드웨어 프로필',
 };
 
 export default ko;

--- a/src/lib/translations/zh.ts
+++ b/src/lib/translations/zh.ts
@@ -785,6 +785,7 @@ const zh: Record<string, string> = {
   'miner.progress': '进度',
   'miner.cliffEnd': '锁定期结束',
   'miner.endTime': '结束时间',
+  'miner.hardwareProfile': '硬件配置',
 };
 
 export default zh;


### PR DESCRIPTION
## Summary
- Add hardware profile section to `/miner/[address]` detail page (GPU, VRAM, backend, CPU, cores, RAM, OS/arch, tier, benchmark, version)
- Update `ApiMinerDetail` type with hardware fields
- Add `miner.hardwareProfile` translation key (en/zh/ja/ko)
- List page stays minimal — full hardware info only on detail page

## Test plan
- [x] TypeScript typecheck passes
- [ ] Verify hardware profile section renders correctly on miner detail page
- [ ] Verify translations display correctly for all 4 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)