### PR TITLE
fix(navbar): mobile menu invisible — z-index conflict with sticky navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -241,7 +241,7 @@ export default function Navbar() {
 
         {/* Mobile hamburger button */}
         <button
-          className="relative z-50 flex h-10 w-10 items-center justify-center rounded-lg text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white md:hidden"
+          className="relative z-[80] flex h-10 w-10 items-center justify-center rounded-lg text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white md:hidden"
           onClick={() => setMobileOpen(!mobileOpen)}
           aria-expanded={mobileOpen}
           aria-label={t('nav.menu')}
@@ -269,7 +269,7 @@ export default function Navbar() {
 
       {/* Mobile overlay backdrop */}
       <div
-        className={`fixed inset-0 z-40 bg-black/50 backdrop-blur-sm transition-opacity duration-300 md:hidden ${
+        className={`fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm transition-opacity duration-300 md:hidden ${
           mobileOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
         }`}
         onClick={closeMobile}
@@ -279,7 +279,7 @@ export default function Navbar() {
       {/* Mobile slide-in panel */}
       <div
         ref={panelRef}
-        className={`fixed right-0 top-0 z-40 flex h-full w-[280px] max-w-[85vw] flex-col bg-white dark:bg-slate-950 shadow-2xl transition-transform duration-300 ease-in-out md:hidden ${
+        className={`fixed right-0 top-0 z-[70] flex h-full w-[280px] max-w-[85vw] flex-col bg-white dark:bg-slate-950 shadow-2xl transition-transform duration-300 ease-in-out md:hidden ${
           mobileOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >


### PR DESCRIPTION
## Bug

Mobile slide-in menu panel was invisible because it had the same `z-40` as the sticky navbar. The panel appeared **behind** the navbar, making the entire menu inaccessible on mobile.

## Root Cause

```
navbar:  z-40  (sticky top-0)
panel:   z-40  ← same! hidden behind navbar
overlay: z-40  ← same!
```

## Fix

```
navbar:         z-40   (unchanged)  
overlay/backdrop: z-[60]  (+20)
slide-in panel:  z-[70]  (+30)
hamburger button: z-[80]  (+40, stays clickable above backdrop)
```

## Verified

Tested at 390px width (iPhone 14 viewport) — menu now slides in from right correctly.

Closes #73 (partial — this fixes the navigation issue; other mobile layout improvements in separate PR)

---
🤖 Filed by Aria Tanaka（田中爱莉）, QA Engineer @ QFC Network — via OpenClaw