### PR TITLE
feat: SEO metadata, sitemap, loading states, and error boundaries

### DIFF
--- a/src/app/gas-tracker/error.tsx
+++ b/src/app/gas-tracker/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+export default function GasTrackerError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col items-center justify-center gap-6 px-6 py-12 text-center">
+      <div className="rounded-2xl border border-red-500/20 bg-red-500/5 p-8">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+          Something went wrong
+        </h2>
+        <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+          {error.message || 'Failed to load gas tracker data.'}
+        </p>
+        <button
+          onClick={reset}
+          className="mt-6 rounded-full border border-slate-300 px-6 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          Try Again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/governance/models/error.tsx
+++ b/src/app/governance/models/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+export default function GovernanceError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col items-center justify-center gap-6 px-6 py-12 text-center">
+      <div className="rounded-2xl border border-red-500/20 bg-red-500/5 p-8">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+          Something went wrong
+        </h2>
+        <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+          {error.message || 'Failed to load governance data.'}
+        </p>
+        <button
+          onClick={reset}
+          className="mt-6 rounded-full border border-slate-300 px-6 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          Try Again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/governance/models/loading.tsx
+++ b/src/app/governance/models/loading.tsx
@@ -1,0 +1,25 @@
+import Skeleton, { SkeletonCard, SkeletonRow } from '@/components/Skeleton';
+
+export default function Loading() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-6 px-6 py-12">
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-36" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <SkeletonCard key={i} />
+        ))}
+      </div>
+
+      <div className="space-y-3">
+        <Skeleton className="h-6 w-40" />
+        {Array.from({ length: 8 }).map((_, i) => (
+          <SkeletonRow key={i} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/inference/error.tsx
+++ b/src/app/inference/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+export default function InferenceError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col items-center justify-center gap-6 px-6 py-12 text-center">
+      <div className="rounded-2xl border border-red-500/20 bg-red-500/5 p-8">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+          Something went wrong
+        </h2>
+        <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+          {error.message || 'Failed to load inference data.'}
+        </p>
+        <button
+          onClick={reset}
+          className="mt-6 rounded-full border border-slate-300 px-6 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          Try Again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/miner/[address]/error.tsx
+++ b/src/app/miner/[address]/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+export default function MinerDetailError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col items-center justify-center gap-6 px-6 py-12 text-center">
+      <div className="rounded-2xl border border-red-500/20 bg-red-500/5 p-8">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+          Something went wrong
+        </h2>
+        <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+          {error.message || 'Failed to load miner details.'}
+        </p>
+        <button
+          onClick={reset}
+          className="mt-6 rounded-full border border-slate-300 px-6 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          Try Again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/miner/[address]/loading.tsx
+++ b/src/app/miner/[address]/loading.tsx
@@ -1,0 +1,23 @@
+import Skeleton, { SkeletonCard } from '@/components/Skeleton';
+
+export default function Loading() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-8 px-6 py-12">
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-4 w-96" />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <SkeletonCard key={i} />
+        ))}
+      </div>
+
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-56 rounded-xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/miner/[address]/page.tsx
+++ b/src/app/miner/[address]/page.tsx
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { fetchJsonSafe } from '@/lib/api-client';
 import type { ApiMinerDetail } from '@/lib/api-types';
@@ -13,6 +14,20 @@ import MinerScoreGauge from '@/components/MinerScoreGauge';
 import MinerEarningsChart from '@/components/MinerEarningsChart';
 import VestingTimeline from '@/components/VestingTimeline';
 import MinerRoiCalculator from '@/components/MinerRoiCalculator';
+
+export async function generateMetadata({ params }: { params: { address: string } }): Promise<Metadata> {
+  const address = params.address;
+  const short = `${address.slice(0, 6)}...${address.slice(-4)}`;
+  return {
+    title: `Miner ${short}`,
+    description: `Inference miner ${short} on the QFC network — performance, earnings, and task history.`,
+    openGraph: {
+      title: `Miner ${short} | QFC Explorer`,
+      description: `Inference miner ${short} on the QFC network.`,
+      type: 'article',
+    },
+  };
+}
 
 export default async function MinerDetailPage({
   params,

--- a/src/app/miners/error.tsx
+++ b/src/app/miners/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+export default function MinersError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col items-center justify-center gap-6 px-6 py-12 text-center">
+      <div className="rounded-2xl border border-red-500/20 bg-red-500/5 p-8">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+          Something went wrong
+        </h2>
+        <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+          {error.message || 'Failed to load miners data.'}
+        </p>
+        <button
+          onClick={reset}
+          className="mt-6 rounded-full border border-slate-300 px-6 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          Try Again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/miners/loading.tsx
+++ b/src/app/miners/loading.tsx
@@ -1,0 +1,25 @@
+import Skeleton, { SkeletonCard, SkeletonRow } from '@/components/Skeleton';
+
+export default function Loading() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-8 px-6 py-12">
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-44" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <SkeletonCard key={i} />
+        ))}
+      </div>
+
+      <div className="space-y-3">
+        <Skeleton className="h-6 w-40" />
+        {Array.from({ length: 10 }).map((_, i) => (
+          <SkeletonRow key={i} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -20,6 +20,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
     '/search',
     '/governance/models',
     '/token/qfc',
+    '/miners',
+    '/pending',
+    '/richlist',
+    '/validators',
+    '/api-docs',
   ];
 
   return staticPages.map((path) => ({

--- a/src/app/task/[taskId]/error.tsx
+++ b/src/app/task/[taskId]/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+export default function TaskError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col items-center justify-center gap-6 px-6 py-12 text-center">
+      <div className="rounded-2xl border border-red-500/20 bg-red-500/5 p-8">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+          Something went wrong
+        </h2>
+        <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+          {error.message || 'Failed to load task details.'}
+        </p>
+        <button
+          onClick={reset}
+          className="mt-6 rounded-full border border-slate-300 px-6 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          Try Again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/task/[taskId]/loading.tsx
+++ b/src/app/task/[taskId]/loading.tsx
@@ -1,0 +1,23 @@
+import Skeleton, { SkeletonCard } from '@/components/Skeleton';
+
+export default function Loading() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 py-12">
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-36" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <SkeletonCard key={i} />
+        ))}
+      </div>
+
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-40 rounded-xl" />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## SEO & Performance Improvements

### Metadata
Added missing `metadata` exports to pages that had none.

### Sitemap
Added 5 missing pages to `src/app/sitemap.ts`:
`/miners`, `/pending`, `/richlist`, `/validators`, `/api-docs`

### Loading States (new loading.tsx)
- `/miners`
- `/miner/[address]`
- `/task/[taskId]`
- `/governance/models`

### Error Boundaries (new error.tsx)
- `/miners`
- `/inference`
- `/miner/[address]`
- `/task/[taskId]`
- `/gas-tracker`
- `/governance/models`

---
🤖 Filed by Aria Tanaka（田中爱莉）, QA Engineer @ QFC Network — via OpenClaw