### PR TITLE
fix: ensure indexer source is copied into Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.git
+*.md
+.env*
+.vscode
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,16 +23,20 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 
-# Copy node_modules and src for indexer (tsx needs these)
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/src ./src
-COPY --from=builder /app/tsconfig.json ./tsconfig.json
+# Copy node_modules from deps (not builder) so cache is tied to package-lock
+COPY --from=deps /app/node_modules ./node_modules
+# Copy src and tsconfig directly from build context to avoid stale COPY --from=builder cache
+COPY src ./src
+COPY tsconfig.json ./tsconfig.json
+
+# Fail fast at build time if indexer source is missing
+RUN test -f src/indexer/index.ts || (echo "ERROR: src/indexer/index.ts not found" && exit 1)
 
 # Create startup script that runs both Next.js and indexer
 RUN echo '#!/bin/sh' > /app/start.sh && \
     echo 'node server.js &' >> /app/start.sh && \
     echo 'sleep 5' >> /app/start.sh && \
-    echo 'npx tsx src/indexer/index.ts' >> /app/start.sh && \
+    echo 'exec ./node_modules/.bin/tsx src/indexer/index.ts' >> /app/start.sh && \
     chmod +x /app/start.sh
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- Copy `src/` and `tsconfig.json` directly from the build context instead of `COPY --from=builder`, which could serve stale layers under BuildKit GHA cache (`mode=max`)
- Copy `node_modules` from the `deps` stage (tied to package-lock) instead of the `builder` stage
- Replace `npx tsx` with `./node_modules/.bin/tsx` to avoid npx resolution issues in the container
- Add build-time assertion that fails if `src/indexer/index.ts` is missing
- Add `.dockerignore` to keep the build context clean

Closes #93

## Test plan
- [ ] Build Docker image: `docker build -t qfc-explorer .`
- [ ] Verify indexer source exists: `docker run --rm qfc-explorer ls -l src/indexer/index.ts`
- [ ] Start container and confirm both Next.js server and indexer launch without crash
- [ ] Deploy to staging and verify indexer processes blocks

🤖 *Submitted by Aria Tanaka（田中爱莉）, QA Engineer @ QFC Network — via OpenClaw*