### PR TITLE
feat(agents): Session Key monitor & Risk Dashboard

### DIFF
--- a/src/app/agent/[agentId]/page.tsx
+++ b/src/app/agent/[agentId]/page.tsx
@@ -188,6 +188,18 @@ export default async function AgentDetailPage({
         >
           View Agent Address
         </Link>
+        <Link
+          href={`/agents/sessions?agent=${encodeURIComponent(agent.agentId)}`}
+          className="rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800"
+        >
+          Session Keys
+        </Link>
+        <Link
+          href={`/agents/risk?agent=${encodeURIComponent(agent.agentId)}`}
+          className="rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800"
+        >
+          Risk Dashboard
+        </Link>
       </section>
     </main>
   );

--- a/src/app/agents/risk/error.tsx
+++ b/src/app/agents/risk/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+export default function RiskDashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col items-center justify-center gap-6 px-6 py-12 text-center">
+      <div className="rounded-2xl border border-red-500/20 bg-red-500/5 p-8">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+          Something went wrong
+        </h2>
+        <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+          {error.message || 'Failed to load risk dashboard data.'}
+        </p>
+        <button
+          onClick={reset}
+          className="mt-6 rounded-full border border-slate-300 px-6 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          Try Again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/agents/risk/loading.tsx
+++ b/src/app/agents/risk/loading.tsx
@@ -1,0 +1,35 @@
+import Skeleton from '@/components/Skeleton';
+
+export default function Loading() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6">
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-52" />
+        <Skeleton className="h-4 w-80" />
+      </div>
+
+      <section className="grid gap-4 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-2xl" />
+        ))}
+      </section>
+
+      <div className="flex gap-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-20 rounded-full" />
+        ))}
+      </div>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-48 rounded-2xl" />
+        ))}
+      </section>
+
+      <div className="space-y-3">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-64 rounded-2xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/agents/risk/page.tsx
+++ b/src/app/agents/risk/page.tsx
@@ -1,0 +1,266 @@
+export const dynamic = "force-dynamic";
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { fetchJsonSafe } from '@/lib/api-client';
+import type { ApiAgentRiskDashboard } from '@/lib/api-types';
+import { shortenHash, formatWeiToQfc } from '@/lib/format';
+import SectionHeader from '@/components/SectionHeader';
+import StatsCard from '@/components/StatsCard';
+import TranslatedText from '@/components/TranslatedText';
+import AutoRefresh from '@/components/AutoRefresh';
+
+export const metadata: Metadata = {
+  title: 'Agent Risk Dashboard',
+  description: 'Operator dashboard for AI agent wallet risk posture — daily spend, limits, violations.',
+  openGraph: {
+    title: 'Agent Risk Dashboard | QFC Explorer',
+    description: 'Monitor AI agent risk posture on the QFC network.',
+    type: 'website',
+  },
+};
+
+function ProgressBar({ current, max, label }: { current: bigint; max: bigint; label: string }) {
+  const pct = max > 0n ? Number((current * 100n) / max) : 0;
+  const color = pct >= 90 ? 'bg-red-500' : pct >= 70 ? 'bg-amber-500' : 'bg-emerald-500';
+  return (
+    <div>
+      <div className="flex items-center justify-between text-xs mb-1.5">
+        <span className="text-slate-500 dark:text-slate-400">{label}</span>
+        <span className="font-mono text-slate-700 dark:text-slate-300">
+          {formatWeiToQfc(current.toString())} / {formatWeiToQfc(max.toString())} QFC
+        </span>
+      </div>
+      <div className="h-2.5 w-full rounded-full bg-slate-200 dark:bg-slate-800 overflow-hidden">
+        <div
+          className={`h-full rounded-full ${color} transition-all duration-300`}
+          style={{ width: `${Math.min(100, pct)}%` }}
+        />
+      </div>
+      <div className="mt-1 text-right text-[10px] text-slate-400">
+        {pct}%
+      </div>
+    </div>
+  );
+}
+
+function ViolationRow({ violation }: { violation: { txHash: string; agentId: string; reason: string; timestamp: string; amount: string } }) {
+  const ts = Number(violation.timestamp) * 1000;
+  const dateStr = Number.isFinite(ts) && ts > 0
+    ? new Date(ts).toLocaleString('en-US', { hour12: false })
+    : '--';
+
+  return (
+    <div className="flex items-start gap-4 border-b border-slate-100 dark:border-slate-800/60 px-4 py-3 last:border-b-0">
+      <div className="flex-shrink-0 mt-0.5">
+        <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-red-500/10 text-red-500">
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+          </svg>
+        </span>
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium text-red-600 dark:text-red-400">{violation.reason}</span>
+          <span className="text-xs text-slate-400">{dateStr}</span>
+        </div>
+        <div className="mt-1 flex items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
+          <span>Agent: <Link href={`/agent/${encodeURIComponent(violation.agentId)}`} className="text-cyan-500 hover:text-cyan-400">{violation.agentId.length > 16 ? violation.agentId.slice(0, 16) + '…' : violation.agentId}</Link></span>
+          {violation.txHash && (
+            <span>Tx: <Link href={`/tx/${violation.txHash}`} className="font-mono text-cyan-500 hover:text-cyan-400">{shortenHash(violation.txHash)}</Link></span>
+          )}
+          {violation.amount !== '0' && (
+            <span>Amount: {formatWeiToQfc(violation.amount)} QFC</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default async function RiskDashboardPage({
+  searchParams,
+}: {
+  searchParams: { owner?: string; agent?: string; status?: string };
+}) {
+  const owner = searchParams.owner ?? '';
+  const agent = searchParams.agent ?? '';
+  const status = searchParams.status ?? '';
+
+  const params = new URLSearchParams();
+  if (owner) params.set('owner', owner);
+  if (agent) params.set('agent', agent);
+  if (status) params.set('status', status);
+
+  const response = await fetchJsonSafe<ApiAgentRiskDashboard>(
+    `/api/agents/risk?${params}`,
+    { next: { revalidate: 15 } }
+  );
+
+  const data = response?.data ?? null;
+  const agents = data?.agents ?? [];
+  const violations = data?.violations ?? [];
+  const stats = data?.stats ?? { totalAgents: 0, activeAgents: 0, totalViolations: 0, totalRejections: 0 };
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6">
+      <AutoRefresh intervalMs={15000} />
+      <SectionHeader
+        title={<TranslatedText tKey="risk.title" />}
+        description={<TranslatedText tKey="risk.description" />}
+        action={
+          <Link
+            href="/agents"
+            className="rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 text-xs uppercase tracking-[0.2em] text-slate-800 dark:text-slate-200"
+          >
+            <TranslatedText tKey="agents.backToList" />
+          </Link>
+        }
+      />
+
+      {/* Summary stats */}
+      <section className="grid gap-4 sm:grid-cols-4">
+        <StatsCard
+          label={<TranslatedText tKey="risk.totalAgents" />}
+          value={String(stats.totalAgents)}
+        />
+        <StatsCard
+          label={<TranslatedText tKey="risk.activeAgents" />}
+          value={String(stats.activeAgents)}
+        />
+        <StatsCard
+          label={<TranslatedText tKey="risk.totalViolations" />}
+          value={String(stats.totalViolations)}
+        />
+        <StatsCard
+          label={<TranslatedText tKey="risk.totalRejections" />}
+          value={String(stats.totalRejections)}
+        />
+      </section>
+
+      {/* Filter tabs */}
+      <div className="flex flex-wrap items-center gap-2">
+        {['', 'active', 'revoked'].map((s) => {
+          const isActive = status === s;
+          const label = s === '' ? 'All' : s.charAt(0).toUpperCase() + s.slice(1);
+          const href = s ? `/agents/risk?status=${s}` : '/agents/risk';
+          return (
+            <Link
+              key={s}
+              href={href}
+              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                isActive
+                  ? 'bg-cyan-500/15 text-cyan-600 dark:text-cyan-400 border border-cyan-500/30'
+                  : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 border border-transparent hover:border-slate-300 dark:hover:border-slate-600'
+              }`}
+            >
+              {label}
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* Agent risk cards */}
+      <section className="grid gap-4 lg:grid-cols-2">
+        {agents.length === 0 ? (
+          <div className="col-span-2 rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 p-8 text-center">
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              No agent risk data available.
+            </p>
+          </div>
+        ) : (
+          agents.map((ag) => {
+            let spentToday: bigint;
+            let dailyLimit: bigint;
+            let maxPerTx: bigint;
+            try { spentToday = BigInt(ag.spentToday); } catch { spentToday = 0n; }
+            try { dailyLimit = BigInt(ag.dailyLimit); } catch { dailyLimit = 0n; }
+            try { maxPerTx = BigInt(ag.maxPerTx); } catch { maxPerTx = 0n; }
+
+            return (
+              <div
+                key={ag.agentId}
+                className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 p-5"
+              >
+                {/* Header */}
+                <div className="flex items-center justify-between mb-4">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Link
+                      href={`/agent/${encodeURIComponent(ag.agentId)}`}
+                      className="text-sm font-medium text-slate-900 dark:text-white hover:text-cyan-400 transition-colors truncate"
+                    >
+                      {ag.agentId}
+                    </Link>
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium ${
+                        ag.active
+                          ? 'bg-emerald-500/20 text-emerald-600 dark:text-emerald-400'
+                          : 'bg-red-500/20 text-red-600 dark:text-red-400'
+                      }`}
+                    >
+                      {ag.active ? 'Active' : 'Revoked'}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-slate-400">
+                    {ag.violationCount > 0 && (
+                      <span className="inline-flex items-center gap-1 text-red-500">
+                        <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01" />
+                        </svg>
+                        {ag.violationCount} violations
+                      </span>
+                    )}
+                    {ag.rejectionCount > 0 && (
+                      <span className="text-amber-500">{ag.rejectionCount} rejected</span>
+                    )}
+                  </div>
+                </div>
+
+                {/* Owner */}
+                <div className="mb-4 text-xs text-slate-500 dark:text-slate-400">
+                  Owner: <Link href={`/address/${ag.owner}`} className="font-mono text-cyan-500 hover:text-cyan-400">{shortenHash(ag.owner)}</Link>
+                </div>
+
+                {/* Daily spend progress */}
+                <div className="space-y-3">
+                  <ProgressBar
+                    current={spentToday}
+                    max={dailyLimit}
+                    label="Daily Spend"
+                  />
+                  <div className="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+                    <span>Max Per Tx</span>
+                    <span className="font-mono">{formatWeiToQfc(maxPerTx.toString())} QFC</span>
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </section>
+
+      {/* Violations feed */}
+      <section>
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+          <TranslatedText tKey="risk.recentViolations" />
+        </h3>
+        <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 overflow-hidden">
+          {violations.length === 0 ? (
+            <div className="p-8 text-center">
+              <div className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-500 mb-3">
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                No violations recorded. All agents operating within limits.
+              </p>
+            </div>
+          ) : (
+            violations.map((v, i) => <ViolationRow key={i} violation={v} />)
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/agents/sessions/error.tsx
+++ b/src/app/agents/sessions/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+export default function SessionKeysError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col items-center justify-center gap-6 px-6 py-12 text-center">
+      <div className="rounded-2xl border border-red-500/20 bg-red-500/5 p-8">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+          Something went wrong
+        </h2>
+        <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+          {error.message || 'Failed to load session keys data.'}
+        </p>
+        <button
+          onClick={reset}
+          className="mt-6 rounded-full border border-slate-300 px-6 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          Try Again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/agents/sessions/loading.tsx
+++ b/src/app/agents/sessions/loading.tsx
@@ -1,0 +1,41 @@
+import Skeleton from '@/components/Skeleton';
+import { SkeletonRow } from '@/components/Skeleton';
+
+export default function Loading() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6">
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+
+      <section className="grid gap-4 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-2xl" />
+        ))}
+      </section>
+
+      <div className="flex gap-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-20 rounded-full" />
+        ))}
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-slate-200 dark:border-slate-800">
+        <div className="flex items-center gap-4 border-b border-slate-200 px-4 py-3 dark:border-slate-800">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-14" />
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+        {Array.from({ length: 8 }).map((_, i) => (
+          <SkeletonRow key={i} cols={8} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/agents/sessions/page.tsx
+++ b/src/app/agents/sessions/page.tsx
@@ -1,0 +1,266 @@
+export const dynamic = "force-dynamic";
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { fetchJsonSafe } from '@/lib/api-client';
+import type { ApiSessionKeysList } from '@/lib/api-types';
+import { shortenHash } from '@/lib/format';
+import SectionHeader from '@/components/SectionHeader';
+import StatsCard from '@/components/StatsCard';
+import Table from '@/components/Table';
+import TranslatedText from '@/components/TranslatedText';
+import AutoRefresh from '@/components/AutoRefresh';
+
+export const metadata: Metadata = {
+  title: 'Session Keys',
+  description: 'Session key monitor — view active, expired, and revoked session keys for AI agents.',
+  openGraph: {
+    title: 'Session Keys | QFC Explorer',
+    description: 'Monitor session keys for AI agents on the QFC network.',
+    type: 'website',
+  },
+};
+
+type SessionKey = ApiSessionKeysList['data']['items'][number];
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    valid: 'bg-emerald-500/20 text-emerald-600 dark:text-emerald-400',
+    expired: 'bg-amber-500/20 text-amber-600 dark:text-amber-400',
+    revoked: 'bg-red-500/20 text-red-600 dark:text-red-400',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${styles[status] ?? 'bg-slate-500/20 text-slate-600 dark:text-slate-400'}`}>
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}
+
+function TtlCountdown({ expiresAt }: { expiresAt: string }) {
+  const ms = Number(expiresAt) * 1000;
+  if (!Number.isFinite(ms) || ms === 0) return <span className="text-slate-400">--</span>;
+  const now = Date.now();
+  const remaining = ms - now;
+  if (remaining <= 0) return <span className="text-amber-500 text-xs">Expired</span>;
+
+  const hours = Math.floor(remaining / 3_600_000);
+  const minutes = Math.floor((remaining % 3_600_000) / 60_000);
+
+  if (hours > 24) {
+    const days = Math.floor(hours / 24);
+    return <span className="text-sm font-mono text-slate-600 dark:text-slate-300">{days}d {hours % 24}h</span>;
+  }
+  return <span className="text-sm font-mono text-slate-600 dark:text-slate-300">{hours}h {minutes}m</span>;
+}
+
+function formatTimestamp(epochSec: string): string {
+  const ms = Number(epochSec) * 1000;
+  if (!Number.isFinite(ms) || ms === 0) return '--';
+  return new Date(ms).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+export default async function SessionKeysPage({
+  searchParams,
+}: {
+  searchParams: { page?: string; status?: string; owner?: string; agent?: string };
+}) {
+  const page = Math.max(1, Number(searchParams.page ?? '1'));
+  const status = searchParams.status ?? '';
+  const owner = searchParams.owner ?? '';
+  const agent = searchParams.agent ?? '';
+
+  const params = new URLSearchParams({ page: String(page), limit: '25' });
+  if (status) params.set('status', status);
+  if (owner) params.set('owner', owner);
+  if (agent) params.set('agent', agent);
+
+  const response = await fetchJsonSafe<ApiSessionKeysList>(
+    `/api/agents/sessions?${params}`,
+    { next: { revalidate: 15 } }
+  );
+
+  const items = response?.data.items ?? [];
+  const total = response?.data.total ?? 0;
+  const stats = response?.data.stats ?? { valid: 0, expired: 0, revoked: 0 };
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6">
+      <AutoRefresh intervalMs={15000} />
+      <SectionHeader
+        title={<TranslatedText tKey="sessions.title" />}
+        description={<TranslatedText tKey="sessions.description" />}
+        action={
+          <Link
+            href="/agents"
+            className="rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 text-xs uppercase tracking-[0.2em] text-slate-800 dark:text-slate-200"
+          >
+            <TranslatedText tKey="agents.backToList" />
+          </Link>
+        }
+      />
+
+      {/* Stats */}
+      <section className="grid gap-4 sm:grid-cols-4">
+        <StatsCard
+          label={<TranslatedText tKey="sessions.totalKeys" />}
+          value={String(total)}
+        />
+        <StatsCard
+          label={<TranslatedText tKey="sessions.validKeys" />}
+          value={String(stats.valid)}
+        />
+        <StatsCard
+          label={<TranslatedText tKey="sessions.expiredKeys" />}
+          value={String(stats.expired)}
+        />
+        <StatsCard
+          label={<TranslatedText tKey="sessions.revokedKeys" />}
+          value={String(stats.revoked)}
+        />
+      </section>
+
+      {/* Filter tabs */}
+      <div className="flex flex-wrap items-center gap-2">
+        {['', 'valid', 'expired', 'revoked'].map((s) => {
+          const isActive = status === s;
+          const label = s === '' ? 'All' : s.charAt(0).toUpperCase() + s.slice(1);
+          const href = s ? `/agents/sessions?status=${s}` : '/agents/sessions';
+          return (
+            <Link
+              key={s}
+              href={href}
+              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                isActive
+                  ? 'bg-cyan-500/15 text-cyan-600 dark:text-cyan-400 border border-cyan-500/30'
+                  : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 border border-transparent hover:border-slate-300 dark:hover:border-slate-600'
+              }`}
+            >
+              {label}
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* Session keys table */}
+      <Table<SessionKey>
+        rows={items}
+        keyField="keyAddress"
+        emptyMessage="No session keys found."
+        columns={[
+          {
+            key: 'keyAddress',
+            header: 'Session Key',
+            render: (row) => (
+              <Link
+                href={`/address/${row.keyAddress}`}
+                className="font-mono text-sm text-slate-800 dark:text-slate-200 hover:text-cyan-400 transition-colors"
+              >
+                {shortenHash(row.keyAddress)}
+              </Link>
+            ),
+          },
+          {
+            key: 'agentId',
+            header: 'Agent',
+            render: (row) => (
+              <Link
+                href={`/agent/${encodeURIComponent(row.agentId)}`}
+                className="font-mono text-sm text-slate-600 dark:text-slate-300 hover:text-cyan-400 transition-colors"
+              >
+                {row.agentId.length > 16 ? row.agentId.slice(0, 16) + '…' : row.agentId}
+              </Link>
+            ),
+          },
+          {
+            key: 'owner',
+            header: 'Owner',
+            render: (row) => (
+              <Link
+                href={`/address/${row.owner}`}
+                className="font-mono text-sm text-slate-600 dark:text-slate-300 hover:text-cyan-400 transition-colors"
+              >
+                {shortenHash(row.owner)}
+              </Link>
+            ),
+          },
+          {
+            key: 'status',
+            header: 'Status',
+            render: (row) => <StatusBadge status={row.status} />,
+          },
+          {
+            key: 'ttl',
+            header: 'TTL Remaining',
+            render: (row) => <TtlCountdown expiresAt={row.expiresAt} />,
+          },
+          {
+            key: 'permissions',
+            header: 'Permissions',
+            render: (row) => (
+              <div className="flex flex-wrap gap-1">
+                {row.permissionLabels.slice(0, 3).map((p, i) => (
+                  <span key={i} className="inline-flex items-center rounded-full bg-cyan-500/10 px-2 py-0.5 text-[10px] font-medium text-cyan-600 dark:text-cyan-400">
+                    {p}
+                  </span>
+                ))}
+                {row.permissionLabels.length > 3 && (
+                  <span className="text-[10px] text-slate-400">+{row.permissionLabels.length - 3}</span>
+                )}
+              </div>
+            ),
+          },
+          {
+            key: 'lastActivity',
+            header: 'Last Activity',
+            render: (row) => (
+              <span className="text-sm text-slate-500 dark:text-slate-400">
+                {row.lastActivityAt ? formatTimestamp(row.lastActivityAt) : '--'}
+              </span>
+            ),
+          },
+          {
+            key: 'createdAt',
+            header: 'Created',
+            render: (row) => (
+              <span className="text-sm text-slate-500 dark:text-slate-400">
+                {formatTimestamp(row.createdAt)}
+              </span>
+            ),
+          },
+        ]}
+      />
+
+      {/* Pagination */}
+      {total > 25 && (
+        <div className="flex items-center justify-center gap-4">
+          {page > 1 && (
+            <Link
+              href={`/agents/sessions?page=${page - 1}${status ? `&status=${status}` : ''}`}
+              className="rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800"
+            >
+              Previous
+            </Link>
+          )}
+          <span className="text-sm text-slate-500 dark:text-slate-400">
+            Page {page}
+          </span>
+          {items.length === 25 && (
+            <Link
+              href={`/agents/sessions?page=${page + 1}${status ? `&status=${status}` : ''}`}
+              className="rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800"
+            >
+              Next
+            </Link>
+          )}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -49,6 +49,14 @@ const NAV_ITEMS: NavItem[] = [
     ],
   },
   {
+    labelKey: 'nav.agentsMenu',
+    children: [
+      { labelKey: 'nav.agentList', href: '/agents' },
+      { labelKey: 'nav.sessionKeys', href: '/agents/sessions' },
+      { labelKey: 'nav.riskDashboard', href: '/agents/risk' },
+    ],
+  },
+  {
     labelKey: 'nav.network',
     children: [
       { labelKey: 'nav.validators', href: '/validators' },

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -834,6 +834,52 @@ export type ApiAgentsList = ApiOk<{
 
 export type ApiAgentDetail = ApiOk<ApiAgentInfo>;
 
+// --- Session Keys ---
+
+export type ApiSessionKeyInfo = {
+  keyAddress: string;
+  agentId: string;
+  owner: string;
+  status: string; // 'valid' | 'expired' | 'revoked'
+  permissions: number[];
+  permissionLabels: string[];
+  createdAt: string;
+  expiresAt: string;
+  lastActivityAt: string | null;
+};
+
+export type ApiSessionKeysList = ApiOk<{
+  total: number;
+  stats: { valid: number; expired: number; revoked: number };
+  items: ApiSessionKeyInfo[];
+}>;
+
+// --- Agent Risk Dashboard ---
+
+export type ApiAgentRiskItem = ApiAgentInfo & {
+  violationCount: number;
+  rejectionCount: number;
+};
+
+export type ApiAgentRiskViolation = {
+  txHash: string;
+  agentId: string;
+  reason: string;
+  timestamp: string;
+  amount: string;
+};
+
+export type ApiAgentRiskDashboard = ApiOk<{
+  stats: {
+    totalAgents: number;
+    activeAgents: number;
+    totalViolations: number;
+    totalRejections: number;
+  };
+  agents: ApiAgentRiskItem[];
+  violations: ApiAgentRiskViolation[];
+}>;
+
 export type ApiMinerDetail = ApiOk<{
   address: string;
   totalEarned: string;

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -817,6 +817,35 @@ const en = {
   'agents.backToList': 'Back to Agents',
   'agents.viewOwner': 'View Owner',
   'agents.viewAgent': 'View Agent Address',
+  'agents.viewSessionKeys': 'Session Keys',
+  'agents.viewRiskDashboard': 'Risk Dashboard',
+
+  // Navigation - Agents
+  'nav.agentsMenu': 'AI Agents',
+  'nav.agentList': 'Agent List',
+  'nav.sessionKeys': 'Session Keys',
+  'nav.riskDashboard': 'Risk Dashboard',
+
+  // Session Keys page
+  'sessions.title': 'Session Keys',
+  'sessions.description': 'Monitor session keys for AI agents — status, TTL, and activity.',
+  'sessions.totalKeys': 'Total Keys',
+  'sessions.validKeys': 'Valid',
+  'sessions.expiredKeys': 'Expired',
+  'sessions.revokedKeys': 'Revoked',
+  'sessions.noKeys': 'No session keys found.',
+
+  // Risk Dashboard page
+  'risk.title': 'Risk Dashboard',
+  'risk.description': 'Operator dashboard for AI agent wallet risk posture.',
+  'risk.totalAgents': 'Total Agents',
+  'risk.activeAgents': 'Active Agents',
+  'risk.totalViolations': 'Violations',
+  'risk.totalRejections': 'Rejections',
+  'risk.recentViolations': 'Recent Violations',
+  'risk.noViolations': 'No violations recorded.',
+  'risk.dailySpend': 'Daily Spend',
+  'risk.maxPerTx': 'Max Per Tx',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/lib/translations/ja.ts
+++ b/src/lib/translations/ja.ts
@@ -811,6 +811,35 @@ const ja: Record<string, string> = {
   'agents.backToList': 'エージェント一覧に戻る',
   'agents.viewOwner': 'オーナーを表示',
   'agents.viewAgent': 'エージェントアドレスを表示',
+  'agents.viewSessionKeys': 'セッションキー',
+  'agents.viewRiskDashboard': 'リスクダッシュボード',
+
+  // Navigation - Agents
+  'nav.agentsMenu': 'AIエージェント',
+  'nav.agentList': 'エージェント一覧',
+  'nav.sessionKeys': 'セッションキー',
+  'nav.riskDashboard': 'リスクダッシュボード',
+
+  // Session Keys
+  'sessions.title': 'セッションキー',
+  'sessions.description': 'AIエージェントのセッションキーを監視 — ステータス、TTL、アクティビティ。',
+  'sessions.totalKeys': 'キー総数',
+  'sessions.validKeys': '有効',
+  'sessions.expiredKeys': '期限切れ',
+  'sessions.revokedKeys': '取消済み',
+  'sessions.noKeys': 'セッションキーが見つかりません。',
+
+  // Risk Dashboard
+  'risk.title': 'リスクダッシュボード',
+  'risk.description': 'AIエージェントウォレットのリスク管理ダッシュボード。',
+  'risk.totalAgents': 'エージェント総数',
+  'risk.activeAgents': 'アクティブ',
+  'risk.totalViolations': '違反数',
+  'risk.totalRejections': '拒否数',
+  'risk.recentViolations': '最近の違反',
+  'risk.noViolations': '違反はありません。',
+  'risk.dailySpend': '日次支出',
+  'risk.maxPerTx': 'Tx毎上限',
 };
 
 export default ja;

--- a/src/lib/translations/ko.ts
+++ b/src/lib/translations/ko.ts
@@ -811,6 +811,35 @@ const ko: Record<string, string> = {
   'agents.backToList': '에이전트 목록으로',
   'agents.viewOwner': '소유자 보기',
   'agents.viewAgent': '에이전트 주소 보기',
+  'agents.viewSessionKeys': '세션 키',
+  'agents.viewRiskDashboard': '리스크 대시보드',
+
+  // Navigation - Agents
+  'nav.agentsMenu': 'AI 에이전트',
+  'nav.agentList': '에이전트 목록',
+  'nav.sessionKeys': '세션 키',
+  'nav.riskDashboard': '리스크 대시보드',
+
+  // Session Keys
+  'sessions.title': '세션 키',
+  'sessions.description': 'AI 에이전트 세션 키 모니터 — 상태, TTL, 활동.',
+  'sessions.totalKeys': '총 키',
+  'sessions.validKeys': '유효',
+  'sessions.expiredKeys': '만료',
+  'sessions.revokedKeys': '취소됨',
+  'sessions.noKeys': '세션 키를 찾을 수 없습니다.',
+
+  // Risk Dashboard
+  'risk.title': '리스크 대시보드',
+  'risk.description': 'AI 에이전트 지갑 리스크 관리 대시보드.',
+  'risk.totalAgents': '총 에이전트',
+  'risk.activeAgents': '활성 에이전트',
+  'risk.totalViolations': '위반 건수',
+  'risk.totalRejections': '거부 건수',
+  'risk.recentViolations': '최근 위반',
+  'risk.noViolations': '위반 기록이 없습니다.',
+  'risk.dailySpend': '일일 지출',
+  'risk.maxPerTx': '거래당 최대',
 };
 
 export default ko;

--- a/src/lib/translations/zh.ts
+++ b/src/lib/translations/zh.ts
@@ -811,6 +811,35 @@ const zh: Record<string, string> = {
   'agents.backToList': '返回代理列表',
   'agents.viewOwner': '查看所有者',
   'agents.viewAgent': '查看代理地址',
+  'agents.viewSessionKeys': '会话密钥',
+  'agents.viewRiskDashboard': '风险面板',
+
+  // Navigation - Agents
+  'nav.agentsMenu': 'AI 代理',
+  'nav.agentList': '代理列表',
+  'nav.sessionKeys': '会话密钥',
+  'nav.riskDashboard': '风险面板',
+
+  // Session Keys
+  'sessions.title': '会话密钥',
+  'sessions.description': '监控 AI 代理会话密钥的状态、TTL 和活动。',
+  'sessions.totalKeys': '密钥总数',
+  'sessions.validKeys': '有效',
+  'sessions.expiredKeys': '已过期',
+  'sessions.revokedKeys': '已撤销',
+  'sessions.noKeys': '未找到会话密钥。',
+
+  // Risk Dashboard
+  'risk.title': '风险面板',
+  'risk.description': 'AI 代理钱包风险态势运维面板。',
+  'risk.totalAgents': '代理总数',
+  'risk.activeAgents': '活跃代理',
+  'risk.totalViolations': '违规次数',
+  'risk.totalRejections': '拒绝次数',
+  'risk.recentViolations': '近期违规',
+  'risk.noViolations': '无违规记录。',
+  'risk.dailySpend': '每日支出',
+  'risk.maxPerTx': '单笔上限',
 };
 
 export default zh;


### PR DESCRIPTION
## Summary
- **Session Key Monitor** (`/agents/sessions`) — list session keys by agent/owner with valid/expired/revoked status, TTL countdown, permissions, and last activity (#96)
- **Risk Dashboard** (`/agents/risk`) — operator dashboard with daily spend progress bars, per-tx cap visibility, violation/rejection counters, and recent violations feed (#97)
- New **AI Agents** nav dropdown with Agent List, Session Keys, and Risk Dashboard
- Quick links from agent detail page to both new pages
- Full i18n support (en/zh/ja/ko)
- API types ready (`ApiSessionKeysList`, `ApiAgentRiskDashboard`) — pages gracefully show empty states until backend endpoints are implemented

Closes #96, closes #97

## Test plan
- [ ] Verify `/agents/sessions` renders with empty state (no backend yet)
- [ ] Verify `/agents/risk` renders with empty state
- [ ] Verify nav dropdown "AI Agents" appears with 3 items
- [ ] Verify agent detail page has Session Keys + Risk Dashboard quick links
- [ ] Check mobile responsive layout
- [ ] Check dark/light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)