### PR TITLE
fix: pass NEXT_PUBLIC_API_URL as Docker build arg

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,6 +52,8 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NEXT_PUBLIC_API_URL=https://api.explorer.testnet.qfc.network
           cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
           cache-to: type=gha,scope=${{ steps.platform.outputs.pair }},mode=max
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 # Limit build workers to avoid QEMU SIGILL on arm64 cross-compile
 ENV NODE_OPTIONS="--max-old-space-size=1024"
+# NEXT_PUBLIC_* vars must be set at build time (inlined into client bundle)
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 RUN npm run build
 
 FROM node:20-alpine AS runner


### PR DESCRIPTION
## Summary
- **Root cause**: `NEXT_PUBLIC_API_URL` was only set as a runtime env var in docker-compose, but Next.js inlines `NEXT_PUBLIC_*` vars into the client bundle at **build time**. Without it, client components (`GasTracker`, `LiveStats`, `use-sse`) fall back to same-origin `/api/*` paths → 404 on the Next.js server.
- **Fix**: Pass `NEXT_PUBLIC_API_URL` as a Docker `ARG` in the builder stage and as a `build-args` in the CI workflow.
- The `/gas-oracle` and `/stream` routes already exist in explorer-api — they just weren't reachable from the browser.

### Changes
- `Dockerfile`: Add `ARG NEXT_PUBLIC_API_URL` + `ENV` in builder stage
- `.github/workflows/docker.yml`: Add `build-args: NEXT_PUBLIC_API_URL=https://api.explorer.testnet.qfc.network`

## Test plan
- [ ] CI builds successfully with the build arg
- [ ] After deploy, verify `https://explorer.testnet.qfc.network` no longer shows `/api/gas-oracle` or `/api/stream` 404s in console
- [ ] Verify GasTracker widget renders on homepage
- [ ] Verify LiveStats SSE connects and shows live block data

🤖 Generated with [Claude Code](https://claude.com/claude-code)