### PR TITLE
feat: agent dashboard + session key manager (#102)

### DIFF
--- a/src/app/agent/[agentId]/page.tsx
+++ b/src/app/agent/[agentId]/page.tsx
@@ -189,10 +189,16 @@ export default async function AgentDetailPage({
           View Agent Address
         </Link>
         <Link
+          href={`/agents/${encodeURIComponent(agent.agentId)}/keys`}
+          className="rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800"
+        >
+          Manage Keys
+        </Link>
+        <Link
           href={`/agents/sessions?agent=${encodeURIComponent(agent.agentId)}`}
           className="rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800"
         >
-          Session Keys
+          Session Keys Monitor
         </Link>
         <Link
           href={`/agents/risk?agent=${encodeURIComponent(agent.agentId)}`}

--- a/src/app/agents/[agentId]/keys/error.tsx
+++ b/src/app/agents/[agentId]/keys/error.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+export default function Error({ reset }: { reset: () => void }) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col items-center justify-center gap-4 px-6 py-12 text-center">
+      <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
+        Failed to load session keys
+      </h2>
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        Session key data could not be loaded. The API may be unavailable.
+      </p>
+      <button
+        onClick={reset}
+        className="mt-4 rounded-full border border-slate-300 dark:border-slate-700 px-6 py-2 text-sm font-medium text-slate-700 dark:text-slate-200 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800"
+      >
+        Retry
+      </button>
+    </main>
+  );
+}

--- a/src/app/agents/[agentId]/keys/loading.tsx
+++ b/src/app/agents/[agentId]/keys/loading.tsx
@@ -1,0 +1,13 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6">
+      <div className="h-8 w-64 animate-pulse rounded bg-slate-200 dark:bg-slate-800" />
+      <div className="grid gap-4 sm:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="h-20 animate-pulse rounded-2xl bg-slate-200 dark:bg-slate-800" />
+        ))}
+      </div>
+      <div className="h-64 animate-pulse rounded-2xl bg-slate-200 dark:bg-slate-800" />
+    </main>
+  );
+}

--- a/src/app/agents/[agentId]/keys/page.tsx
+++ b/src/app/agents/[agentId]/keys/page.tsx
@@ -1,0 +1,189 @@
+export const dynamic = "force-dynamic";
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { fetchJsonSafe } from '@/lib/api-client';
+import type { ApiAgentSessionKeys, ApiSessionKeyInfo } from '@/lib/api-types';
+import { shortenHash } from '@/lib/format';
+import SectionHeader from '@/components/SectionHeader';
+import Table from '@/components/Table';
+import AutoRefresh from '@/components/AutoRefresh';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { agentId: string };
+}): Promise<Metadata> {
+  const id = decodeURIComponent(params.agentId);
+  return {
+    title: `Session Keys — ${id}`,
+    description: `Manage session keys for agent "${id}".`,
+  };
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    valid: 'bg-emerald-500/20 text-emerald-400',
+    expired: 'bg-slate-500/20 text-slate-400',
+    revoked: 'bg-red-500/20 text-red-400',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${styles[status] ?? 'bg-slate-500/20 text-slate-400'}`}>
+      {status}
+    </span>
+  );
+}
+
+function TTLCountdown({ expiresAt }: { expiresAt: string }) {
+  const expMs = Number(expiresAt) * 1000;
+  if (!Number.isFinite(expMs) || expMs === 0) return <span className="text-slate-500">--</span>;
+  const now = Date.now();
+  const diff = expMs - now;
+  if (diff <= 0) return <span className="text-red-400">Expired</span>;
+
+  const hours = Math.floor(diff / 3600000);
+  const mins = Math.floor((diff % 3600000) / 60000);
+  if (hours > 24) {
+    const days = Math.floor(hours / 24);
+    return <span className="text-emerald-400">{days}d {hours % 24}h</span>;
+  }
+  if (hours > 0) return <span className="text-amber-400">{hours}h {mins}m</span>;
+  return <span className="text-red-400">{mins}m</span>;
+}
+
+function formatTimestamp(epochSec: string): string {
+  const ms = Number(epochSec) * 1000;
+  if (!Number.isFinite(ms) || ms === 0) return '--';
+  return new Date(ms).toLocaleString('en-US', { hour12: false });
+}
+
+export default async function AgentKeysPage({
+  params,
+}: {
+  params: { agentId: string };
+}) {
+  const agentId = decodeURIComponent(params.agentId);
+
+  const response = await fetchJsonSafe<ApiAgentSessionKeys>(
+    `/api/agents/${encodeURIComponent(agentId)}/session-keys`,
+    { next: { revalidate: 15 } }
+  );
+
+  const keys = response?.data.items ?? [];
+  const total = response?.data.total ?? 0;
+  const validCount = keys.filter(k => k.status === 'valid').length;
+  const expiredCount = keys.filter(k => k.status === 'expired').length;
+  const revokedCount = keys.filter(k => k.status === 'revoked').length;
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6">
+      <AutoRefresh intervalMs={15000} />
+      <SectionHeader
+        title={`Session Keys: ${agentId}`}
+        description={`Manage session keys for this agent — view active keys, permissions, usage, and revocation status.`}
+        action={
+          <Link
+            href={`/agent/${encodeURIComponent(agentId)}`}
+            className="rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 text-xs uppercase tracking-[0.2em] text-slate-800 dark:text-slate-200"
+          >
+            Back to Agent
+          </Link>
+        }
+      />
+
+      {/* Stats row */}
+      <section className="grid gap-4 sm:grid-cols-4">
+        <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 p-5 text-center">
+          <p className="text-xs font-medium uppercase tracking-wider text-slate-400 dark:text-slate-500">Total</p>
+          <p className="mt-1 text-2xl font-bold text-slate-900 dark:text-white">{total}</p>
+        </div>
+        <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 p-5 text-center">
+          <p className="text-xs font-medium uppercase tracking-wider text-emerald-500">Valid</p>
+          <p className="mt-1 text-2xl font-bold text-emerald-400">{validCount}</p>
+        </div>
+        <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 p-5 text-center">
+          <p className="text-xs font-medium uppercase tracking-wider text-slate-400">Expired</p>
+          <p className="mt-1 text-2xl font-bold text-slate-400">{expiredCount}</p>
+        </div>
+        <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 p-5 text-center">
+          <p className="text-xs font-medium uppercase tracking-wider text-red-500">Revoked</p>
+          <p className="mt-1 text-2xl font-bold text-red-400">{revokedCount}</p>
+        </div>
+      </section>
+
+      {/* Keys table */}
+      <Table<ApiSessionKeyInfo>
+        rows={keys}
+        keyField="keyAddress"
+        emptyMessage="No session keys found for this agent."
+        columns={[
+          {
+            key: 'keyAddress',
+            header: 'Key Address',
+            render: (row) => (
+              <Link
+                href={`/address/${row.keyAddress}`}
+                className="font-mono text-sm text-slate-800 dark:text-slate-200 hover:text-cyan-400 transition-colors"
+              >
+                {shortenHash(row.keyAddress)}
+              </Link>
+            ),
+          },
+          {
+            key: 'status',
+            header: 'Status',
+            render: (row) => <StatusBadge status={row.status} />,
+          },
+          {
+            key: 'expiresAt',
+            header: 'TTL',
+            render: (row) => <TTLCountdown expiresAt={row.expiresAt} />,
+          },
+          {
+            key: 'permissions',
+            header: 'Permissions',
+            render: (row) => (
+              <div className="flex flex-wrap gap-1">
+                {row.permissionLabels.map((perm, i) => (
+                  <span
+                    key={i}
+                    className="inline-flex items-center rounded-full bg-cyan-500/10 px-2 py-0.5 text-xs font-medium text-cyan-400"
+                  >
+                    {perm}
+                  </span>
+                ))}
+              </div>
+            ),
+          },
+          {
+            key: 'lastActivityAt',
+            header: 'Last Activity',
+            render: (row) => (
+              <span className="text-sm text-slate-500 dark:text-slate-400">
+                {row.lastActivityAt ? formatTimestamp(row.lastActivityAt) : 'Never'}
+              </span>
+            ),
+          },
+          {
+            key: 'createdAt',
+            header: 'Created',
+            render: (row) => (
+              <span className="text-sm text-slate-500 dark:text-slate-400">
+                {formatTimestamp(row.createdAt)}
+              </span>
+            ),
+          },
+          {
+            key: 'expiresAt2',
+            header: 'Expires',
+            render: (row) => (
+              <span className="text-sm text-slate-500 dark:text-slate-400">
+                {formatTimestamp(row.expiresAt)}
+              </span>
+            ),
+          },
+        ]}
+      />
+    </main>
+  );
+}

--- a/src/app/agents/dashboard/error.tsx
+++ b/src/app/agents/dashboard/error.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+export default function Error({ reset }: { reset: () => void }) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col items-center justify-center gap-4 px-6 py-12 text-center">
+      <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
+        Failed to load dashboard
+      </h2>
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        The agent dashboard data could not be loaded. The API may be unavailable.
+      </p>
+      <button
+        onClick={reset}
+        className="mt-4 rounded-full border border-slate-300 dark:border-slate-700 px-6 py-2 text-sm font-medium text-slate-700 dark:text-slate-200 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800"
+      >
+        Retry
+      </button>
+    </main>
+  );
+}

--- a/src/app/agents/dashboard/loading.tsx
+++ b/src/app/agents/dashboard/loading.tsx
@@ -1,0 +1,14 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6">
+      <div className="h-8 w-48 animate-pulse rounded bg-slate-200 dark:bg-slate-800" />
+      <div className="grid gap-4 sm:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="h-24 animate-pulse rounded-2xl bg-slate-200 dark:bg-slate-800" />
+        ))}
+      </div>
+      <div className="h-48 animate-pulse rounded-2xl bg-slate-200 dark:bg-slate-800" />
+      <div className="h-64 animate-pulse rounded-2xl bg-slate-200 dark:bg-slate-800" />
+    </main>
+  );
+}

--- a/src/app/agents/dashboard/page.tsx
+++ b/src/app/agents/dashboard/page.tsx
@@ -1,0 +1,233 @@
+export const dynamic = "force-dynamic";
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { fetchJsonSafe } from '@/lib/api-client';
+import type { ApiAgentDashboard, ApiAgentInfo, ApiAgentAlert, ApiSpendingPoint } from '@/lib/api-types';
+import { formatNumber, shortenHash, formatWeiToQfc } from '@/lib/format';
+import SectionHeader from '@/components/SectionHeader';
+import StatsCard from '@/components/StatsCard';
+import Table from '@/components/Table';
+import TranslatedText from '@/components/TranslatedText';
+import AutoRefresh from '@/components/AutoRefresh';
+
+export const metadata: Metadata = {
+  title: 'Agent Dashboard',
+  description: 'Operator dashboard for your AI agents — spending, alerts, and status.',
+};
+
+function AlertBadge({ type }: { type: string }) {
+  const colors: Record<string, string> = {
+    high_spend: 'bg-amber-500/20 text-amber-400',
+    limit_reached: 'bg-red-500/20 text-red-400',
+    key_expiring: 'bg-yellow-500/20 text-yellow-400',
+    revoked: 'bg-red-500/20 text-red-400',
+  };
+  const labels: Record<string, string> = {
+    high_spend: 'High Spend',
+    limit_reached: 'Limit Reached',
+    key_expiring: 'Key Expiring',
+    revoked: 'Revoked',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${colors[type] ?? 'bg-slate-500/20 text-slate-400'}`}>
+      {labels[type] ?? type}
+    </span>
+  );
+}
+
+function SpendBar({ spent, limit }: { spent: string; limit: string }) {
+  const s = Number(spent);
+  const l = Number(limit);
+  if (l === 0) return <span className="text-xs text-slate-500">No limit</span>;
+  const pct = Math.min((s / l) * 100, 100);
+  const color = pct >= 90 ? 'bg-red-500' : pct >= 70 ? 'bg-amber-500' : 'bg-emerald-500';
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 h-2 rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden">
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">{pct.toFixed(0)}%</span>
+    </div>
+  );
+}
+
+function formatTimestamp(epochSec: string): string {
+  const ms = Number(epochSec) * 1000;
+  if (!Number.isFinite(ms) || ms === 0) return '--';
+  return new Date(ms).toLocaleString('en-US', { hour12: false });
+}
+
+export default async function AgentDashboardPage({
+  searchParams,
+}: {
+  searchParams: { owner?: string };
+}) {
+  const ownerParam = searchParams.owner ? `?owner=${encodeURIComponent(searchParams.owner)}` : '';
+  const response = await fetchJsonSafe<ApiAgentDashboard>(
+    `/api/agents/dashboard${ownerParam}`,
+    { next: { revalidate: 15 } }
+  );
+
+  const stats = response?.data.stats ?? { totalAgents: 0, activeAgents: 0, totalDeposit: '0', totalSpentToday: '0' };
+  const agents = response?.data.agents ?? [];
+  const alerts = response?.data.alerts ?? [];
+  const spendingTrend = response?.data.spendingTrend ?? [];
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6">
+      <AutoRefresh intervalMs={15000} />
+      <SectionHeader
+        title={<TranslatedText tKey="dashboard.title" />}
+        description={<TranslatedText tKey="dashboard.description" />}
+        action={
+          <Link
+            href="/agents"
+            className="rounded-full border border-slate-300 dark:border-slate-700 px-4 py-2 text-xs uppercase tracking-[0.2em] text-slate-800 dark:text-slate-200"
+          >
+            All Agents
+          </Link>
+        }
+      />
+
+      {/* Stats */}
+      <section className="grid gap-4 sm:grid-cols-4">
+        <StatsCard label={<TranslatedText tKey="agents.totalAgents" />} value={formatNumber(stats.totalAgents)} />
+        <StatsCard label={<TranslatedText tKey="agents.activeAgents" />} value={formatNumber(stats.activeAgents)} />
+        <StatsCard label={<TranslatedText tKey="agents.totalDeposit" />} value={`${formatWeiToQfc(stats.totalDeposit)} QFC`} />
+        <StatsCard label={<TranslatedText tKey="dashboard.spentToday" />} value={`${formatWeiToQfc(stats.totalSpentToday)} QFC`} />
+      </section>
+
+      {/* Alerts */}
+      {alerts.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-3">
+            <TranslatedText tKey="dashboard.alerts" />
+          </h3>
+          <div className="space-y-2">
+            {alerts.map((alert, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-3 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 px-4 py-3"
+              >
+                <AlertBadge type={alert.type} />
+                <Link
+                  href={`/agent/${encodeURIComponent(alert.agentId)}`}
+                  className="font-mono text-sm text-slate-700 dark:text-slate-300 hover:text-cyan-400 transition-colors"
+                >
+                  {alert.agentId}
+                </Link>
+                <span className="flex-1 text-sm text-slate-600 dark:text-slate-400">{alert.message}</span>
+                <span className="text-xs text-slate-400">{formatTimestamp(alert.timestamp)}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Spending Trend */}
+      {spendingTrend.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-3">
+            <TranslatedText tKey="dashboard.spendingTrend" />
+          </h3>
+          <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 p-6">
+            <div className="flex items-end gap-1 h-32">
+              {spendingTrend.map((point, i) => {
+                const maxVal = Math.max(...spendingTrend.map(p => Number(p.amount)), 1);
+                const height = (Number(point.amount) / maxVal) * 100;
+                return (
+                  <div key={i} className="flex-1 flex flex-col items-center gap-1">
+                    <div
+                      className="w-full rounded-t bg-cyan-500/70 min-h-[2px]"
+                      style={{ height: `${height}%` }}
+                      title={`${point.date}: ${formatWeiToQfc(point.amount)} QFC`}
+                    />
+                    <span className="text-[10px] text-slate-400 truncate w-full text-center">
+                      {point.date.slice(5)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* My Agents */}
+      <section>
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-3">
+          <TranslatedText tKey="dashboard.myAgents" />
+        </h3>
+        <Table<ApiAgentInfo>
+          rows={agents}
+          keyField="agentId"
+          emptyMessage="No agents found. Connect your wallet or specify ?owner=0x..."
+          columns={[
+            {
+              key: 'agentId',
+              header: 'Agent ID',
+              render: (row) => (
+                <Link
+                  href={`/agent/${encodeURIComponent(row.agentId)}`}
+                  className="font-mono text-sm text-slate-800 dark:text-slate-200 hover:text-cyan-400 transition-colors"
+                >
+                  {row.agentId}
+                </Link>
+              ),
+            },
+            {
+              key: 'deposit',
+              header: 'Deposit',
+              render: (row) => (
+                <span className="font-mono text-sm text-slate-600 dark:text-slate-300">
+                  {formatWeiToQfc(row.deposit)} QFC
+                </span>
+              ),
+            },
+            {
+              key: 'spentToday',
+              header: 'Daily Spend',
+              render: (row) => <SpendBar spent={row.spentToday} limit={row.dailyLimit} />,
+            },
+            {
+              key: 'active',
+              header: 'Status',
+              render: (row) => (
+                <span
+                  className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                    row.active
+                      ? 'bg-emerald-500/20 text-emerald-400'
+                      : 'bg-red-500/20 text-red-400'
+                  }`}
+                >
+                  {row.active ? 'Active' : 'Revoked'}
+                </span>
+              ),
+            },
+            {
+              key: 'actions',
+              header: '',
+              render: (row) => (
+                <div className="flex gap-2">
+                  <Link
+                    href={`/agents/${encodeURIComponent(row.agentId)}/keys`}
+                    className="text-xs text-cyan-500 hover:text-cyan-400 transition-colors"
+                  >
+                    Keys
+                  </Link>
+                  <Link
+                    href={`/agents/risk?agent=${encodeURIComponent(row.agentId)}`}
+                    className="text-xs text-cyan-500 hover:text-cyan-400 transition-colors"
+                  >
+                    Risk
+                  </Link>
+                </div>
+              ),
+            },
+          ]}
+        />
+      </section>
+    </main>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -52,6 +52,7 @@ const NAV_ITEMS: NavItem[] = [
     labelKey: 'nav.agentsMenu',
     children: [
       { labelKey: 'nav.agentList', href: '/agents' },
+      { labelKey: 'nav.agentDashboard', href: '/agents/dashboard' },
       { labelKey: 'nav.sessionKeys', href: '/agents/sessions' },
       { labelKey: 'nav.riskDashboard', href: '/agents/risk' },
     ],

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -880,6 +880,56 @@ export type ApiAgentRiskDashboard = ApiOk<{
   violations: ApiAgentRiskViolation[];
 }>;
 
+// --- Agent Dashboard ---
+
+export type ApiAgentDashboard = ApiOk<{
+  stats: {
+    totalAgents: number;
+    activeAgents: number;
+    totalDeposit: string;
+    totalSpentToday: string;
+  };
+  agents: ApiAgentInfo[];
+  alerts: ApiAgentAlert[];
+  spendingTrend: ApiSpendingPoint[];
+}>;
+
+export type ApiAgentAlert = {
+  agentId: string;
+  type: 'high_spend' | 'limit_reached' | 'key_expiring' | 'revoked';
+  message: string;
+  timestamp: string;
+};
+
+export type ApiSpendingPoint = {
+  date: string;
+  amount: string;
+};
+
+// --- Agent Transactions ---
+
+export type ApiAgentTransaction = {
+  hash: string;
+  from: string;
+  to: string;
+  value: string;
+  status: number;
+  timestamp: string;
+  method: string;
+};
+
+export type ApiAgentTransactions = ApiOk<{
+  total: number;
+  items: ApiAgentTransaction[];
+}>;
+
+// --- Agent Session Keys (per agent) ---
+
+export type ApiAgentSessionKeys = ApiOk<{
+  total: number;
+  items: ApiSessionKeyInfo[];
+}>;
+
 export type ApiMinerDetail = ApiOk<{
   address: string;
   totalEarned: string;

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -835,6 +835,18 @@ const en = {
   'sessions.revokedKeys': 'Revoked',
   'sessions.noKeys': 'No session keys found.',
 
+  // Agent Dashboard page
+  'dashboard.title': 'Agent Dashboard',
+  'dashboard.description': 'Operator view — your agents, alerts, and spending trends.',
+  'dashboard.spentToday': 'Spent Today',
+  'dashboard.alerts': 'Alerts',
+  'dashboard.spendingTrend': 'Spending Trend (7d)',
+  'dashboard.myAgents': 'My Agents',
+  'dashboard.noAlerts': 'No alerts.',
+
+  // Navigation - Dashboard
+  'nav.agentDashboard': 'Dashboard',
+
   // Risk Dashboard page
   'risk.title': 'Risk Dashboard',
   'risk.description': 'Operator dashboard for AI agent wallet risk posture.',

--- a/src/lib/translations/ja.ts
+++ b/src/lib/translations/ja.ts
@@ -840,6 +840,16 @@ const ja: Record<string, string> = {
   'risk.noViolations': '違反はありません。',
   'risk.dailySpend': '日次支出',
   'risk.maxPerTx': 'Tx毎上限',
+
+  // Agent Dashboard
+  'dashboard.title': 'エージェントダッシュボード',
+  'dashboard.description': 'オペレータービュー — エージェント、アラート、支出トレンド。',
+  'dashboard.spentToday': '本日の支出',
+  'dashboard.alerts': 'アラート',
+  'dashboard.spendingTrend': '支出トレンド (7日)',
+  'dashboard.myAgents': 'マイエージェント',
+  'dashboard.noAlerts': 'アラートなし。',
+  'nav.agentDashboard': 'ダッシュボード',
 };
 
 export default ja;

--- a/src/lib/translations/ko.ts
+++ b/src/lib/translations/ko.ts
@@ -840,6 +840,16 @@ const ko: Record<string, string> = {
   'risk.noViolations': '위반 기록이 없습니다.',
   'risk.dailySpend': '일일 지출',
   'risk.maxPerTx': '거래당 최대',
+
+  // Agent Dashboard
+  'dashboard.title': '에이전트 대시보드',
+  'dashboard.description': '운영자 뷰 — 에이전트, 알림, 지출 추세.',
+  'dashboard.spentToday': '오늘 지출',
+  'dashboard.alerts': '알림',
+  'dashboard.spendingTrend': '지출 추세 (7일)',
+  'dashboard.myAgents': '내 에이전트',
+  'dashboard.noAlerts': '알림 없음.',
+  'nav.agentDashboard': '대시보드',
 };
 
 export default ko;

--- a/src/lib/translations/zh.ts
+++ b/src/lib/translations/zh.ts
@@ -840,6 +840,16 @@ const zh: Record<string, string> = {
   'risk.noViolations': '无违规记录。',
   'risk.dailySpend': '每日支出',
   'risk.maxPerTx': '单笔上限',
+
+  // Agent Dashboard
+  'dashboard.title': 'Agent 控制台',
+  'dashboard.description': '运营视图 — 您的 Agent、告警和消费趋势。',
+  'dashboard.spentToday': '今日消费',
+  'dashboard.alerts': '告警',
+  'dashboard.spendingTrend': '消费趋势 (7天)',
+  'dashboard.myAgents': '我的 Agent',
+  'dashboard.noAlerts': '暂无告警。',
+  'nav.agentDashboard': '控制台',
 };
 
 export default zh;


### PR DESCRIPTION
## Summary
- **`/agents/dashboard`** — Operator view with owned agents, alerts (high spend, limit reached, key expiring, revoked), 7-day spending trend bar chart, daily spend progress bars per agent
- **`/agents/:id/keys`** — Per-agent session key manager with stats cards (total/valid/expired/revoked), TTL countdown, permissions chips, activity timestamps
- Updated agent detail page with "Manage Keys" quick link
- Added "Dashboard" to AI Agents nav dropdown
- New API types: `ApiAgentDashboard`, `ApiAgentAlert`, `ApiSpendingPoint`, `ApiAgentTransaction`, `ApiAgentSessionKeys`
- Translations in 4 languages (en/zh/ja/ko)

Partially addresses #102 (frontend pages done; API endpoints, indexer, and database work tracked separately)

## Checklist from #102
- [x] `/agents` — paginated agent list *(already existed)*
- [x] `/agents/:id` — agent detail *(already existed, updated with keys link)*
- [x] `/agents/dashboard` — operator view ✨ NEW
- [x] `/agents/:id/keys` — session key manager ✨ NEW
- [ ] API endpoints (qfc-explorer-api)
- [ ] Indexer event subscriptions (qfc-explorer-api)
- [ ] Database tables (qfc-explorer-api)

## Test plan
- [x] `npm run typecheck` passes
- [ ] Visual check of dashboard and keys pages
- [ ] Verify API integration when endpoints are built

🤖 Generated with [Claude Code](https://claude.com/claude-code)