### PR TITLE
docs: English README as default + Chinese version, cross-linked

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,59 @@
 # QFC Explorer
 
-QFC 区块浏览器（Next.js + PostgreSQL + Indexer）。
+**English** | [中文](./README.zh-CN.md)
 
-## 环境变量
+Block explorer **frontend** for the QFC blockchain, built with Next.js 14 (App Router), React 18, TypeScript, and Tailwind CSS.
 
-| 变量 | 说明 | 示例 |
+Live: https://explorer.testnet.qfc.network
+
+> All backend logic — REST API, PostgreSQL, and the chain indexer — lives in [qfc-explorer-api](https://github.com/qfc-network/qfc-explorer-api). This repo is the UI only and talks to that service over HTTP.
+
+## Features
+
+- Blocks, transactions, addresses, tokens (ERC-20 / NFT), and contract pages
+- Contract read/write interaction and source verification
+- AI inference tasks, miner revenue dashboard, validators and network analytics
+- DEX, bridge, and gas-tracker views
+- i18n (English / 中文 / 日本語 / 한국어), dark mode, live updates
+
+## Environment Variables
+
+| Variable | Description | Example |
 | --- | --- | --- |
-| `DATABASE_URL` | PostgreSQL 连接串 | `postgres://qfc:qfc@localhost:5432/qfc_explorer` |
-| `RPC_URL` | QFC 节点 JSON-RPC 地址 | `http://127.0.0.1:8545` |
-| `NEXT_PUBLIC_BASE_URL` | SSR 请求 API 的基础 URL | `http://localhost:3000` |
-| `INDEXER_START_HEIGHT` | 索引起始高度 | `0` |
-| `INDEXER_END_HEIGHT` | 索引结束高度（可选） | `1000` |
-| `INDEXER_POLL_INTERVAL_MS` | 轮询间隔 | `10000` |
-| `INDEXER_USE_FINALIZED` | 使用 finalized 高度 | `true` |
-| `INDEXER_BLOCK_RETRIES` | 单块重试次数 | `3` |
-| `INDEXER_SKIP_ON_ERROR` | 失败跳过 | `false` |
-| `INDEXER_RETRY_FAILED` | 启动时重试失败块 | `false` |
-| `INDEXER_HEALTH_MAX_AGE_MS` | 健康检查最大滞后 | `300000` |
-| `SSE_INTERVAL_MS` | 实时推送间隔（最小 3000） | `5000` |
+| `API_URL` | Backend base URL for server-side (SSR) fetches; not exposed to the browser | `http://explorer-api:3001` |
+| `NEXT_PUBLIC_API_URL` | Backend base URL for browser fetches; also the SSR fallback | `https://api.explorer.testnet.qfc.network` |
 
-生产环境模板：`.env.production.example`
+If neither is set, the app falls back to relative `/api` routes (useful behind a reverse proxy that routes `/api` to the backend).
 
-## 快速开始（本地）
+## Quick Start
 
 ```bash
 npm install
-cp .env.example .env
-# set DATABASE_URL and RPC_URL
-npm run db:migrate
+export NEXT_PUBLIC_API_URL=https://api.explorer.testnet.qfc.network
 npm run dev
 ```
 
-## 快速开始（Docker）
+Open `http://localhost:3000`.
+
+## Commands
 
 ```bash
-export RPC_URL=http://127.0.0.1:8545
-
-docker compose up --build
-
-docker compose exec explorer npm run db:migrate
+npm run dev        # dev server
+npm run build      # production build
+npm run start      # serve the production build
+npm run lint       # eslint
+npm run typecheck  # tsc --noEmit
+npm test           # vitest
 ```
 
-使用 profiles 只启动某个服务：
-```bash
-docker compose --profile explorer up --build
-docker compose --profile indexer up --build
-```
+## Deployment
 
-访问：`http://localhost:3000`
+A `Dockerfile` is included; images are built by CI from the `staging` branch and deployed via [qfc-testnet](https://github.com/qfc-network/qfc-testnet). Point `API_URL` / `NEXT_PUBLIC_API_URL` at a running qfc-explorer-api instance.
 
-## 常用命令
+## Related Repositories
 
-```bash
-npm run db:migrate        # 迁移
-npm run indexer           # 运行索引器
-npm run indexer:health    # 索引器健康检查
-npm run data:check        # 数据一致性检查
-npm test                  # 测试
-```
-
-## API 概览
-
-- `GET /api/blocks?page&limit&order&producer`
-- `GET /api/blocks/:height?page&limit&order`
-- `GET /api/transactions?page&limit&order&address&status`
-- `GET /api/txs/:hash`
-- `GET /api/address/:address?page&limit&order`
-- `GET /api/tokens?page&limit&order`
-- `GET /api/tokens/:address?page&limit&order`
-- `GET /api/tokens/:address/holders?limit`
-- `GET /api/search?q=`
-- `GET /api/search/suggest?q=`
-- `GET /api/network`
-- `GET /api/stats`
-
-响应统一格式：
-```json
-{ "ok": true, "data": { ... } }
-```
-
-## 备注
-- Indexer 需要可用的 QFC RPC。
-- API 集成测试要求服务可访问（`NEXT_PUBLIC_BASE_URL`）。
+| Repo | Role |
+| --- | --- |
+| [qfc-explorer-api](https://github.com/qfc-network/qfc-explorer-api) | REST API + PostgreSQL + chain indexer |
+| [qfc-core](https://github.com/qfc-network/qfc-core) | Blockchain node (JSON-RPC source) |
+| [qfc-testnet](https://github.com/qfc-network/qfc-testnet) | Testnet deployment infrastructure |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,59 @@
+# QFC 区块浏览器
+
+[English](./README.md) | **中文**
+
+QFC 区块链浏览器**前端**,基于 Next.js 14(App Router)、React 18、TypeScript 和 Tailwind CSS 构建。
+
+线上地址:https://explorer.testnet.qfc.network
+
+> 所有后端逻辑——REST API、PostgreSQL、链上索引器——都在 [qfc-explorer-api](https://github.com/qfc-network/qfc-explorer-api) 仓库。本仓库只是 UI,通过 HTTP 调用该服务。
+
+## 功能
+
+- 区块、交易、地址、代币(ERC-20 / NFT)、合约页面
+- 合约读写交互与源码验证
+- AI 推理任务、矿工收益仪表盘、验证人与网络分析
+- DEX、跨链桥、Gas 追踪视图
+- 多语言(English / 中文 / 日本語 / 한국어)、暗色模式、实时更新
+
+## 环境变量
+
+| 变量 | 说明 | 示例 |
+| --- | --- | --- |
+| `API_URL` | 服务端(SSR)请求的后端基础 URL,不暴露给浏览器 | `http://explorer-api:3001` |
+| `NEXT_PUBLIC_API_URL` | 浏览器请求的后端基础 URL,同时是 SSR 的回退值 | `https://api.explorer.testnet.qfc.network` |
+
+两者都未设置时,应用回退到相对路径 `/api`(适用于由反向代理把 `/api` 转发到后端的部署)。
+
+## 快速开始
+
+```bash
+npm install
+export NEXT_PUBLIC_API_URL=https://api.explorer.testnet.qfc.network
+npm run dev
+```
+
+访问 `http://localhost:3000`。
+
+## 常用命令
+
+```bash
+npm run dev        # 开发服务器
+npm run build      # 生产构建
+npm run start      # 运行生产构建
+npm run lint       # eslint
+npm run typecheck  # tsc --noEmit
+npm test           # vitest
+```
+
+## 部署
+
+仓库内含 `Dockerfile`;CI 从 `staging` 分支构建镜像,经 [qfc-testnet](https://github.com/qfc-network/qfc-testnet) 部署。将 `API_URL` / `NEXT_PUBLIC_API_URL` 指向运行中的 qfc-explorer-api 实例即可。
+
+## 相关仓库
+
+| 仓库 | 角色 |
+| --- | --- |
+| [qfc-explorer-api](https://github.com/qfc-network/qfc-explorer-api) | REST API + PostgreSQL + 链上索引器 |
+| [qfc-core](https://github.com/qfc-network/qfc-core) | 区块链节点(JSON-RPC 数据源) |
+| [qfc-testnet](https://github.com/qfc-network/qfc-testnet) | 测试网部署基础设施 |


### PR DESCRIPTION
- `README.md` → English (default), `README.zh-CN.md` → Chinese, each linking to the other at the top.
- **Rewritten, not translated**: the old README documented `db:migrate`/`indexer`/`data:check` commands and `DATABASE_URL`/`INDEXER_*` env vars that no longer exist in this repo (backend + indexer moved to qfc-explorer-api). Both new files document the actual frontend: `API_URL` / `NEXT_PUBLIC_API_URL` (verified against `src/lib/api-client.ts` fallback logic), real `package.json` scripts, staging-branch image pipeline, related repos.

Follow-up (not in this PR): `.env.example` and `docker-compose.yml` still carry the stale DATABASE_URL/indexer surface and should get the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)